### PR TITLE
Asmyrogl/b 04

### DIFF
--- a/docs/pr-messages/b-04-entity-collision-system-pr.md
+++ b/docs/pr-messages/b-04-entity-collision-system-pr.md
@@ -1,0 +1,79 @@
+# PR Gate Checklist
+
+Local test command reference (run what applies to your change and list what you ran in the `## Tests` section below):
+
+- Baseline for every change: `npm run check`, `npm run fix`, `npm run test`, `npm run policy`
+- Unit-only slices: `npm run test:unit`
+- Cross-system or adapter changes: `npm run test:integration`
+- Browser/runtime behavior changes (pause, input, HUD, rendering, gameplay): `npm run test:e2e`
+- Audit-map updates: `npm run test:audit`
+- Manifest/schema updates: `npm run validate:schema`
+- Local checks rerun with prepared metadata: `npm run policy:checks:local`
+- Repo-only troubleshooting rerun: `npm run policy:repo`
+
+## Required checks
+
+- [x] I read AGENTS.md and the agentic workflow guide.
+- [ ] I ran `npm run policy` locally.
+ - [x] I verified my branch name follows `<owner-or-scope>/<TRACK>-<NN>[-<COMMENT>]` (for example `ekaramet/A-03` or `asmyrogl/B-03-runtime-integration`), or I marked the PR body with `process` for a GENERAL_DOCS_PROCESS branch.
+- [x] I confirmed changed files stay within the declared ticket ownership scope.
+- [x] I ran the applicable local checks for this change.
+- [x] I listed each affected AUDIT ID with execution type (Fully Automatable, Semi-Automatable, or Manual-With-Evidence) and linked the passing test output or evidence artifact.
+- [x] I confirmed full audit coverage remains mapped for F-01 through F-21 and B-01 through B-06.
+- [x] If affected, I attached Manual-With-Evidence artifacts for F-19, F-20, F-21, and B-06.
+- [x] I checked security sinks and trust boundaries.
+- [x] I checked architecture boundaries.
+- [x] I checked dependency and lockfile impact.
+- [ ] I requested human review.
+
+## Layer boundary confirmation
+
+- [x] `src/ecs/systems/` has no DOM references except `render-dom-system.js`
+- [x] Simulation systems access adapters only through World resources (no direct adapter imports)
+- [x] `src/adapters/` owns DOM and browser I/O side effects
+- [x] Untrusted UI content uses safe sinks (`textContent` / explicit attributes), not HTML injection
+- [x] No framework imports or canvas APIs were introduced in this change
+
+## What changed
+- Implemented `src/ecs/systems/collision-system.js` for B-04 using a deterministic cell-occupancy approach for player, ghost, bomb, and fire collisions.
+- Added static pickup collection for pellets, power pellets, and map power-ups, clearing collected cells immediately and recording collision intents instead of mutating score/lives directly.
+- Implemented the collision priority required by the ticket: invincibility over fire, and fire over ghost contact.
+- Implemented fire vs player, fire vs ghost, normal ghost contact vs player, and harmless stunned-ghost contact handling.
+- Enforced ghost-house occupancy rules: player blocked from `G`, ghosts allowed to exit, and only dead ghosts allowed to re-enter.
+- Enforced bomb-cell rules, including path-around blocking and shared-cell bomb push-back when a bomb is dropped on a ghost's current tile.
+- Added focused unit coverage in `tests/unit/systems/collision-system.test.js`.
+- Added gameplay integration coverage in `tests/integration/gameplay/b-04-collision-system.test.js` to validate ECS phase ordering and mixed collision scenarios through `World.runFixedStep()`.
+
+## Why
+- B-04 owns the gameplay-correct overlap rules between player, ghosts, bombs, fire, pellets, and power-ups.
+- The collision system needs deterministic ordering so later scoring, lives, audio, and event-surface tickets can consume stable intent output.
+- Ghost-house and bomb-cell rules are part of the gameplay contract, not optional polish, so they need to live in simulation rather than being left to later runtime wiring.
+- The integration tests lock the `physics -> logic` collision path so future movement or system-registration changes do not silently break gameplay behavior.
+
+## Tests
+- User-reported: all applicable tests were run locally and passed.
+- Focused collision verification also passed for:
+  - `npx vitest run tests/unit/systems/collision-system.test.js tests/integration/gameplay/b-04-collision-system.test.js`
+  - `npm run test:unit`
+  - `npm run test:integration`
+  - `npx biome check src/ecs/systems/collision-system.js tests/unit/systems/collision-system.test.js tests/integration/gameplay/b-04-collision-system.test.js`
+
+## Audit questions affected
+- `AUDIT-F-13 | Execution type: Fully Automatable | Verification: collision permutations and gameplay interaction coverage in tests/unit/systems/collision-system.test.js and tests/integration/gameplay/b-04-collision-system.test.js | Evidence path/link: tests/unit/systems/collision-system.test.js, tests/integration/gameplay/b-04-collision-system.test.js`
+
+## Security notes
+- No unsafe DOM sinks, inline event handlers, framework imports, canvas APIs, or dynamic code execution were introduced.
+- The change stays inside ECS simulation and test code, so it does not expand the browser trust boundary.
+- Collision results are recorded as intents in plain data structures rather than dispatched through DOM or adapter side effects.
+
+## Architecture / dependency notes
+- `src/ecs/systems/collision-system.js` remains a simulation system with no DOM access and no direct adapter imports.
+- The system reads and writes only World resources and ECS component stores.
+- Score/life authority is intentionally left to later consumers of collision intents, which keeps B-04 within its ownership boundary.
+- Runtime registration of the collision system and downstream intent consumers are still owned by other tickets/tracks.
+- `docs/implementation/ticket-tracker.md` still lists `A-11` as a blocker for `B-04`; if your team has explicitly approved proceeding anyway, reviewers should note that exception in PR discussion.
+
+## Risks
+- Runtime wiring is still pending outside this ticket, so this PR completes the collision system itself but not full in-game registration.
+- `ghostStore.state` is updated to `DEAD` immediately on fire kill to prevent repeated death intents; if B-08 later centralizes ghost state transitions, that contract may need to be revisited.
+- Ghost-house entry is currently enforced as "dead ghosts only" based on the existing map geometry; if future maps expose additional ghost-house perimeter shapes, the rule may need to become a more explicit gate model.

--- a/src/ecs/systems/collision-system.js
+++ b/src/ecs/systems/collision-system.js
@@ -33,7 +33,7 @@
 import { COMPONENT_MASK } from '../components/registry.js';
 import { COLLIDER_TYPE } from '../components/spatial.js';
 import { CELL_TYPE, GHOST_STATE } from '../resources/constants.js';
-import { getCell, setCell } from '../resources/map-resource.js';
+import { getCell, isGhostHouseCell, setCell } from '../resources/map-resource.js';
 
 /**
  * Dynamic entities with tile positions are queried through position + collider.
@@ -87,6 +87,39 @@ export function readEntityTile(positionStore, entityId, outTile = { row: 0, col:
   outTile.row = Math.round(positionStore.row[entityId]);
   outTile.col = Math.round(positionStore.col[entityId]);
   return outTile;
+}
+
+/**
+ * Copy one entity's previous tile into a reusable output object.
+ *
+ * @param {PositionStore | null | undefined} positionStore - Position component store.
+ * @param {number} entityId - Entity slot to read.
+ * @param {{ row: number, col: number }} [outTile] - Reusable target object.
+ * @returns {{ row: number, col: number } | null} The populated tile object, or null when missing.
+ */
+function readPreviousEntityTile(positionStore, entityId, outTile = { row: 0, col: 0 }) {
+  if (!positionStore) {
+    return null;
+  }
+
+  outTile.row = Math.round(positionStore.prevRow[entityId]);
+  outTile.col = Math.round(positionStore.prevCol[entityId]);
+  return outTile;
+}
+
+/**
+ * Snap one entity back onto a specific tile.
+ *
+ * @param {PositionStore} positionStore - Mutable position store.
+ * @param {number} entityId - Entity slot to mutate.
+ * @param {number} row - Tile row to occupy.
+ * @param {number} col - Tile col to occupy.
+ */
+function setEntityTile(positionStore, entityId, row, col) {
+  positionStore.row[entityId] = row;
+  positionStore.col[entityId] = col;
+  positionStore.targetRow[entityId] = row;
+  positionStore.targetCol[entityId] = col;
 }
 
 /**
@@ -228,7 +261,10 @@ function readTileFromCellIndex(mapResource, cellIndex, outTile) {
 }
 
 /**
- * Build the per-cell occupancy data needed for deterministic collision checks.
+ * Populate occupancy lanes for bombs and fire only.
+ *
+ * These colliders are the inputs for later actor constraint checks, so they
+ * must be recorded before player and ghost occupancy is finalized.
  *
  * @param {number[]} entityIds - Queried dynamic entity IDs for this step.
  * @param {MapResource} mapResource - Map resource providing bounds.
@@ -237,7 +273,7 @@ function readTileFromCellIndex(mapResource, cellIndex, outTile) {
  * @param {CollisionScratch} scratch - Reusable occupancy scratch buffer.
  * @param {{ row: number, col: number }} reusableTile - Shared temporary tile object.
  */
-function buildDynamicOccupancy(
+function buildHazardOccupancy(
   entityIds,
   mapResource,
   positionStore,
@@ -253,11 +289,6 @@ function buildDynamicOccupancy(
     }
 
     const colliderType = colliderStore.type[entityId];
-    if (colliderType === COLLIDER_TYPE.PLAYER) {
-      scratch.playerByCell[cellIndex] = entityId;
-      continue;
-    }
-
     if (colliderType === COLLIDER_TYPE.FIRE) {
       scratch.fireByCell[cellIndex] = entityId;
       continue;
@@ -265,11 +296,105 @@ function buildDynamicOccupancy(
 
     if (colliderType === COLLIDER_TYPE.BOMB) {
       scratch.bombByCell[cellIndex] = entityId;
+    }
+  }
+}
+
+/**
+ * Check whether a ghost may legally occupy a ghost-house tile this step.
+ *
+ * Ghosts may always remain inside or exit the house, but only dead ghosts may
+ * enter it from outside.
+ *
+ * @param {MapResource} mapResource - Map resource with ghost-house geometry.
+ * @param {GhostStore | null | undefined} ghostStore - Ghost gameplay store.
+ * @param {number} entityId - Ghost entity slot to inspect.
+ * @param {{ row: number, col: number }} currentTile - Current ghost tile.
+ * @param {{ row: number, col: number }} previousTile - Previous ghost tile.
+ * @returns {boolean} True when the current ghost-house occupancy is legal.
+ */
+function canGhostOccupyGhostHouse(mapResource, ghostStore, entityId, currentTile, previousTile) {
+  if (!isGhostHouseCell(mapResource, currentTile.row, currentTile.col)) {
+    return true;
+  }
+
+  if (isGhostHouseCell(mapResource, previousTile.row, previousTile.col)) {
+    return true;
+  }
+
+  return (ghostStore?.state?.[entityId] ?? GHOST_STATE.NORMAL) === GHOST_STATE.DEAD;
+}
+
+/**
+ * Check whether a ghost should be blocked from entering a bomb cell this step.
+ *
+ * Staying on the same bomb cell is tolerated here because the one-time
+ * bomb-drop push-back rule is handled separately from this occupancy check.
+ *
+ * @param {CollisionScratch} scratch - Reusable occupancy scratch buffer.
+ * @param {number} currentCellIndex - Ghost's current flat cell index.
+ * @param {number} previousCellIndex - Ghost's previous flat cell index.
+ * @returns {boolean} True when the ghost attempted to enter an occupied bomb cell.
+ */
+function shouldBlockGhostFromBombCell(scratch, currentCellIndex, previousCellIndex) {
+  if (scratch.bombByCell[currentCellIndex] === -1) {
+    return false;
+  }
+
+  return currentCellIndex !== previousCellIndex;
+}
+
+/**
+ * Enforce ghost-house and bomb-cell occupancy rules by reverting illegal moves.
+ *
+ * @param {number[]} entityIds - Queried dynamic entity IDs for this step.
+ * @param {MapResource} mapResource - Map resource with ghost-house geometry.
+ * @param {PositionStore} positionStore - Mutable position store.
+ * @param {ColliderStore} colliderStore - Collider component store.
+ * @param {GhostStore | null | undefined} ghostStore - Ghost gameplay store.
+ * @param {CollisionScratch} scratch - Reusable occupancy scratch buffer.
+ * @param {{ row: number, col: number }} currentTile - Shared current-tile object.
+ * @param {{ row: number, col: number }} previousTile - Shared previous-tile object.
+ */
+function enforceOccupancyConstraints(
+  entityIds,
+  mapResource,
+  positionStore,
+  colliderStore,
+  ghostStore,
+  scratch,
+  currentTile,
+  previousTile,
+) {
+  for (const entityId of entityIds) {
+    const colliderType = colliderStore.type[entityId];
+    if (colliderType !== COLLIDER_TYPE.PLAYER && colliderType !== COLLIDER_TYPE.GHOST) {
       continue;
     }
 
-    if (colliderType === COLLIDER_TYPE.GHOST) {
-      pushGhostOccupancy(scratch, cellIndex, entityId);
+    const current = readEntityTile(positionStore, entityId, currentTile);
+    const previous = readPreviousEntityTile(positionStore, entityId, previousTile);
+    const currentCellIndex = tileToCellIndex(mapResource, current.row, current.col);
+    const previousCellIndex = tileToCellIndex(mapResource, previous.row, previous.col);
+
+    if (colliderType === COLLIDER_TYPE.PLAYER) {
+      if (isGhostHouseCell(mapResource, current.row, current.col)) {
+        setEntityTile(positionStore, entityId, previous.row, previous.col);
+      }
+      continue;
+    }
+
+    if (!canGhostOccupyGhostHouse(mapResource, ghostStore, entityId, current, previous)) {
+      setEntityTile(positionStore, entityId, previous.row, previous.col);
+      continue;
+    }
+
+    if (
+      currentCellIndex >= 0 &&
+      previousCellIndex >= 0 &&
+      shouldBlockGhostFromBombCell(scratch, currentCellIndex, previousCellIndex)
+    ) {
+      setEntityTile(positionStore, entityId, previous.row, previous.col);
     }
   }
 }
@@ -345,6 +470,43 @@ export function collectStaticPickup(mapResource, collisionIntents, entityId, row
     col,
     powerUpType,
   });
+}
+
+/**
+ * Record final player and ghost occupancy after constraints have been enforced.
+ *
+ * @param {number[]} entityIds - Queried dynamic entity IDs for this step.
+ * @param {MapResource} mapResource - Map resource providing bounds.
+ * @param {PositionStore} positionStore - Position component store.
+ * @param {ColliderStore} colliderStore - Collider component store.
+ * @param {CollisionScratch} scratch - Reusable occupancy scratch buffer.
+ * @param {{ row: number, col: number }} reusableTile - Shared temporary tile object.
+ */
+function buildActorOccupancy(
+  entityIds,
+  mapResource,
+  positionStore,
+  colliderStore,
+  scratch,
+  reusableTile,
+) {
+  for (const entityId of entityIds) {
+    const tile = readEntityTile(positionStore, entityId, reusableTile);
+    const cellIndex = tileToCellIndex(mapResource, tile.row, tile.col);
+    if (cellIndex < 0) {
+      continue;
+    }
+
+    const colliderType = colliderStore.type[entityId];
+    if (colliderType === COLLIDER_TYPE.PLAYER) {
+      scratch.playerByCell[cellIndex] = entityId;
+      continue;
+    }
+
+    if (colliderType === COLLIDER_TYPE.GHOST) {
+      pushGhostOccupancy(scratch, cellIndex, entityId);
+    }
+  }
 }
 
 /**
@@ -473,6 +635,7 @@ export function createCollisionSystem(options = {}) {
   let scratch = null;
   const reusableTile = { row: 0, col: 0 };
   const reusableCellTile = { row: 0, col: 0 };
+  const reusablePreviousTile = { row: 0, col: 0 };
 
   return {
     name: 'collision-system',
@@ -515,7 +678,25 @@ export function createCollisionSystem(options = {}) {
       );
 
       const entityIds = world.query(requiredMask);
-      buildDynamicOccupancy(
+      buildHazardOccupancy(
+        entityIds,
+        mapResource,
+        positionStore,
+        colliderStore,
+        scratch,
+        reusableTile,
+      );
+      enforceOccupancyConstraints(
+        entityIds,
+        mapResource,
+        positionStore,
+        colliderStore,
+        ghostStore,
+        scratch,
+        reusableTile,
+        reusablePreviousTile,
+      );
+      buildActorOccupancy(
         entityIds,
         mapResource,
         positionStore,

--- a/src/ecs/systems/collision-system.js
+++ b/src/ecs/systems/collision-system.js
@@ -27,14 +27,19 @@
  *   schema decision here.
  * - The system records collision intents but does not award score or mutate
  *   player lives directly; later tickets consume these intents.
- * - The one-time "bomb dropped on a shared ghost cell" push-back rule is not
- *   approximated here because it needs an explicit placement-edge signal.
+ * - Shared-cell bomb push-back is inferred from bomb movement between the
+ *   previous and current fixed-step tiles so the rule stays local to B-04.
  */
 
 import { COMPONENT_MASK } from '../components/registry.js';
 import { COLLIDER_TYPE } from '../components/spatial.js';
 import { CELL_TYPE, GHOST_STATE } from '../resources/constants.js';
-import { getCell, isGhostHouseCell, setCell } from '../resources/map-resource.js';
+import {
+  getCell,
+  isGhostHouseCell,
+  isPassableForGhost,
+  setCell,
+} from '../resources/map-resource.js';
 
 /**
  * Dynamic entities with tile positions are queried through position + collider.
@@ -137,6 +142,7 @@ export function createCollisionScratch(cellCount, maxGhostsPerCell = DEFAULT_GHO
     // Single-lane colliders use -1 to mean "no entity occupies this cell yet".
     playerByCell: new Int32Array(cellCount).fill(-1),
     bombByCell: new Int32Array(cellCount).fill(-1),
+    droppedBombByCell: new Int32Array(cellCount).fill(-1),
     fireByCell: new Int32Array(cellCount).fill(-1),
     // Ghosts need a compact fan-out lane because multiple ghosts can share one tile.
     ghostCounts: new Uint8Array(cellCount),
@@ -153,6 +159,7 @@ export function createCollisionScratch(cellCount, maxGhostsPerCell = DEFAULT_GHO
 export function resetCollisionScratch(scratch) {
   scratch.playerByCell.fill(-1);
   scratch.bombByCell.fill(-1);
+  scratch.droppedBombByCell.fill(-1);
   scratch.fireByCell.fill(-1);
   scratch.ghostCounts.fill(0);
   scratch.ghostIds.fill(-1);
@@ -262,6 +269,44 @@ function readTileFromCellIndex(mapResource, cellIndex, outTile) {
 }
 
 /**
+ * Check whether an entity changed tiles during the current fixed step.
+ *
+ * @param {{ row: number, col: number }} currentTile - Entity's current tile.
+ * @param {{ row: number, col: number }} previousTile - Entity's previous tile.
+ * @returns {boolean} True when the entity occupies a different tile this step.
+ */
+function hasTileChanged(currentTile, previousTile) {
+  return currentTile.row !== previousTile.row || currentTile.col !== previousTile.col;
+}
+
+/**
+ * Resolve the ghost's current travel direction from prior and target tiles.
+ *
+ * The collision system does not own ghost movement state, so it infers travel
+ * direction from the tile delta that already exists in the shared position store.
+ *
+ * @param {PositionStore} positionStore - Position component store.
+ * @param {number} entityId - Ghost entity slot to inspect.
+ * @param {{ row: number, col: number }} currentTile - Current tile.
+ * @param {{ row: number, col: number }} previousTile - Previous tile.
+ * @param {{ rowDelta: number, colDelta: number }} outVector - Reusable travel vector.
+ * @returns {{ rowDelta: number, colDelta: number }} The populated travel vector.
+ */
+function readGhostTravelDirection(positionStore, entityId, currentTile, previousTile, outVector) {
+  outVector.rowDelta = Math.sign(currentTile.row - previousTile.row);
+  outVector.colDelta = Math.sign(currentTile.col - previousTile.col);
+  if (outVector.rowDelta !== 0 || outVector.colDelta !== 0) {
+    return outVector;
+  }
+
+  // When the ghost has not changed tile yet this step, the target tile still
+  // exposes its intended travel direction from the movement system.
+  outVector.rowDelta = Math.sign(Math.round(positionStore.targetRow[entityId]) - currentTile.row);
+  outVector.colDelta = Math.sign(Math.round(positionStore.targetCol[entityId]) - currentTile.col);
+  return outVector;
+}
+
+/**
  * Populate occupancy lanes for bombs and fire only.
  *
  * These colliders are the inputs for later actor constraint checks, so they
@@ -272,7 +317,8 @@ function readTileFromCellIndex(mapResource, cellIndex, outTile) {
  * @param {PositionStore} positionStore - Position component store.
  * @param {ColliderStore} colliderStore - Collider component store.
  * @param {CollisionScratch} scratch - Reusable occupancy scratch buffer.
- * @param {{ row: number, col: number }} reusableTile - Shared temporary tile object.
+ * @param {{ row: number, col: number }} reusableTile - Shared current-tile object.
+ * @param {{ row: number, col: number }} reusablePreviousTile - Shared previous-tile object.
  */
 function buildHazardOccupancy(
   entityIds,
@@ -281,10 +327,11 @@ function buildHazardOccupancy(
   colliderStore,
   scratch,
   reusableTile,
+  reusablePreviousTile,
 ) {
   for (const entityId of entityIds) {
-    const tile = readEntityTile(positionStore, entityId, reusableTile);
-    const cellIndex = tileToCellIndex(mapResource, tile.row, tile.col);
+    const currentTile = readEntityTile(positionStore, entityId, reusableTile);
+    const cellIndex = tileToCellIndex(mapResource, currentTile.row, currentTile.col);
     if (cellIndex < 0) {
       continue;
     }
@@ -297,6 +344,10 @@ function buildHazardOccupancy(
 
     if (colliderType === COLLIDER_TYPE.BOMB) {
       scratch.bombByCell[cellIndex] = entityId;
+      const previousTile = readPreviousEntityTile(positionStore, entityId, reusablePreviousTile);
+      if (hasTileChanged(currentTile, previousTile)) {
+        scratch.droppedBombByCell[cellIndex] = entityId;
+      }
     }
   }
 }
@@ -327,10 +378,95 @@ function canGhostOccupyGhostHouse(mapResource, ghostStore, entityId, currentTile
 }
 
 /**
- * Check whether a ghost should be blocked from entering a bomb cell this step.
+ * Check whether one tile is legal for a ghost to occupy after bomb push-back.
  *
- * Staying on the same bomb cell is tolerated here because the one-time
- * bomb-drop push-back rule is handled separately from this occupancy check.
+ * @param {MapResource} mapResource - Map resource with tile semantics.
+ * @param {GhostStore | null | undefined} ghostStore - Ghost gameplay store.
+ * @param {CollisionScratch} scratch - Reusable occupancy scratch buffer.
+ * @param {number} entityId - Ghost entity slot to inspect.
+ * @param {{ row: number, col: number }} candidateTile - Proposed destination tile.
+ * @param {{ row: number, col: number }} currentTile - Ghost tile before displacement.
+ * @returns {boolean} True when the tile is legal for the ghost.
+ */
+function canPushGhostIntoTile(
+  mapResource,
+  ghostStore,
+  scratch,
+  entityId,
+  candidateTile,
+  currentTile,
+) {
+  const candidateCellIndex = tileToCellIndex(mapResource, candidateTile.row, candidateTile.col);
+  if (candidateCellIndex < 0) {
+    return false;
+  }
+
+  if (!isPassableForGhost(mapResource, candidateTile.row, candidateTile.col)) {
+    return false;
+  }
+
+  if (!canGhostOccupyGhostHouse(mapResource, ghostStore, entityId, candidateTile, currentTile)) {
+    return false;
+  }
+
+  // Push-back must not move the ghost directly into another active bomb cell.
+  return scratch.bombByCell[candidateCellIndex] === -1;
+}
+
+/**
+ * Push a ghost away from a newly dropped shared-cell bomb when possible.
+ *
+ * The primary rule uses the ghost's current travel direction. If that target is
+ * unavailable, falling back to the previous tile still breaks the illegal
+ * bomb-sharing state deterministically without inventing a broader pathfinding rule.
+ *
+ * @param {MapResource} mapResource - Map resource with tile semantics.
+ * @param {PositionStore} positionStore - Mutable position store.
+ * @param {GhostStore | null | undefined} ghostStore - Ghost gameplay store.
+ * @param {CollisionScratch} scratch - Reusable occupancy scratch buffer.
+ * @param {number} entityId - Ghost entity slot to move.
+ * @param {{ row: number, col: number }} currentTile - Current ghost tile.
+ * @param {{ row: number, col: number }} previousTile - Previous ghost tile.
+ * @param {{ rowDelta: number, colDelta: number }} travelVector - Reusable travel vector.
+ * @param {{ row: number, col: number }} candidateTile - Reusable candidate tile object.
+ * @returns {boolean} True when the ghost was displaced away from the bomb cell.
+ */
+function pushGhostOffDroppedBomb(
+  mapResource,
+  positionStore,
+  ghostStore,
+  scratch,
+  entityId,
+  currentTile,
+  previousTile,
+  travelVector,
+  candidateTile,
+) {
+  readGhostTravelDirection(positionStore, entityId, currentTile, previousTile, travelVector);
+  if (travelVector.rowDelta !== 0 || travelVector.colDelta !== 0) {
+    candidateTile.row = currentTile.row + travelVector.rowDelta;
+    candidateTile.col = currentTile.col + travelVector.colDelta;
+    if (
+      canPushGhostIntoTile(mapResource, ghostStore, scratch, entityId, candidateTile, currentTile)
+    ) {
+      setEntityTile(positionStore, entityId, candidateTile.row, candidateTile.col);
+      return true;
+    }
+  }
+
+  if (
+    hasTileChanged(currentTile, previousTile) &&
+    canPushGhostIntoTile(mapResource, ghostStore, scratch, entityId, previousTile, currentTile)
+  ) {
+    setEntityTile(positionStore, entityId, previousTile.row, previousTile.col);
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Check whether a ghost should be blocked from entering an occupied bomb cell.
  *
  * @param {CollisionScratch} scratch - Reusable occupancy scratch buffer.
  * @param {number} currentCellIndex - Ghost's current flat cell index.
@@ -356,6 +492,8 @@ function shouldBlockGhostFromBombCell(scratch, currentCellIndex, previousCellInd
  * @param {CollisionScratch} scratch - Reusable occupancy scratch buffer.
  * @param {{ row: number, col: number }} currentTile - Shared current-tile object.
  * @param {{ row: number, col: number }} previousTile - Shared previous-tile object.
+ * @param {{ rowDelta: number, colDelta: number }} travelVector - Shared travel-direction object.
+ * @param {{ row: number, col: number }} candidateTile - Shared candidate-tile object.
  */
 function enforceOccupancyConstraints(
   entityIds,
@@ -366,6 +504,8 @@ function enforceOccupancyConstraints(
   scratch,
   currentTile,
   previousTile,
+  travelVector,
+  candidateTile,
 ) {
   for (const entityId of entityIds) {
     const colliderType = colliderStore.type[entityId];
@@ -382,6 +522,24 @@ function enforceOccupancyConstraints(
       if (isGhostHouseCell(mapResource, current.row, current.col)) {
         setEntityTile(positionStore, entityId, previous.row, previous.col);
       }
+      continue;
+    }
+
+    if (
+      currentCellIndex >= 0 &&
+      scratch.droppedBombByCell[currentCellIndex] !== -1 &&
+      pushGhostOffDroppedBomb(
+        mapResource,
+        positionStore,
+        ghostStore,
+        scratch,
+        entityId,
+        current,
+        previous,
+        travelVector,
+        candidateTile,
+      )
+    ) {
       continue;
     }
 
@@ -637,6 +795,8 @@ export function createCollisionSystem(options = {}) {
   const reusableTile = { row: 0, col: 0 };
   const reusableCellTile = { row: 0, col: 0 };
   const reusablePreviousTile = { row: 0, col: 0 };
+  const reusableTravelVector = { rowDelta: 0, colDelta: 0 };
+  const reusableCandidateTile = { row: 0, col: 0 };
 
   return {
     name: 'collision-system',
@@ -679,6 +839,7 @@ export function createCollisionSystem(options = {}) {
         colliderStore,
         scratch,
         reusableTile,
+        reusablePreviousTile,
       );
       enforceOccupancyConstraints(
         entityIds,
@@ -689,6 +850,8 @@ export function createCollisionSystem(options = {}) {
         scratch,
         reusableTile,
         reusablePreviousTile,
+        reusableTravelVector,
+        reusableCandidateTile,
       );
       buildActorOccupancy(
         entityIds,

--- a/src/ecs/systems/collision-system.js
+++ b/src/ecs/systems/collision-system.js
@@ -32,7 +32,7 @@
 
 import { COMPONENT_MASK } from '../components/registry.js';
 import { COLLIDER_TYPE } from '../components/spatial.js';
-import { CELL_TYPE } from '../resources/constants.js';
+import { CELL_TYPE, GHOST_STATE } from '../resources/constants.js';
 import { getCell, setCell } from '../resources/map-resource.js';
 
 /**
@@ -197,6 +197,84 @@ function ensureCollisionScratch(scratch, cellCount, maxGhostsPerCell) {
 }
 
 /**
+ * Add one ghost entity to the occupancy lanes for a cell.
+ *
+ * @param {CollisionScratch} scratch - Reusable occupancy scratch buffer.
+ * @param {number} cellIndex - Flat cell index receiving the ghost.
+ * @param {number} entityId - Ghost entity occupying the cell.
+ */
+function pushGhostOccupancy(scratch, cellIndex, entityId) {
+  const ghostCount = scratch.ghostCounts[cellIndex];
+  if (ghostCount >= scratch.maxGhostsPerCell) {
+    return;
+  }
+
+  scratch.ghostIds[cellIndex * scratch.maxGhostsPerCell + ghostCount] = entityId;
+  scratch.ghostCounts[cellIndex] = ghostCount + 1;
+}
+
+/**
+ * Convert one flat cell index back into tile coordinates.
+ *
+ * @param {MapResource} mapResource - Map dimensions source.
+ * @param {number} cellIndex - Flat cell index to decode.
+ * @param {{ row: number, col: number }} outTile - Reusable tile object.
+ * @returns {{ row: number, col: number }} The populated tile object.
+ */
+function readTileFromCellIndex(mapResource, cellIndex, outTile) {
+  outTile.row = Math.floor(cellIndex / mapResource.cols);
+  outTile.col = cellIndex % mapResource.cols;
+  return outTile;
+}
+
+/**
+ * Build the per-cell occupancy data needed for deterministic collision checks.
+ *
+ * @param {number[]} entityIds - Queried dynamic entity IDs for this step.
+ * @param {MapResource} mapResource - Map resource providing bounds.
+ * @param {PositionStore} positionStore - Position component store.
+ * @param {ColliderStore} colliderStore - Collider component store.
+ * @param {CollisionScratch} scratch - Reusable occupancy scratch buffer.
+ * @param {{ row: number, col: number }} reusableTile - Shared temporary tile object.
+ */
+function buildDynamicOccupancy(
+  entityIds,
+  mapResource,
+  positionStore,
+  colliderStore,
+  scratch,
+  reusableTile,
+) {
+  for (const entityId of entityIds) {
+    const tile = readEntityTile(positionStore, entityId, reusableTile);
+    const cellIndex = tileToCellIndex(mapResource, tile.row, tile.col);
+    if (cellIndex < 0) {
+      continue;
+    }
+
+    const colliderType = colliderStore.type[entityId];
+    if (colliderType === COLLIDER_TYPE.PLAYER) {
+      scratch.playerByCell[cellIndex] = entityId;
+      continue;
+    }
+
+    if (colliderType === COLLIDER_TYPE.FIRE) {
+      scratch.fireByCell[cellIndex] = entityId;
+      continue;
+    }
+
+    if (colliderType === COLLIDER_TYPE.BOMB) {
+      scratch.bombByCell[cellIndex] = entityId;
+      continue;
+    }
+
+    if (colliderType === COLLIDER_TYPE.GHOST) {
+      pushGhostOccupancy(scratch, cellIndex, entityId);
+    }
+  }
+}
+
+/**
  * Translate one static map power-up cell into the canonical gameplay type name.
  *
  * @param {number} cellType - Static map cell type at the player's tile.
@@ -270,6 +348,103 @@ export function collectStaticPickup(mapResource, collisionIntents, entityId, row
 }
 
 /**
+ * Resolve dynamic fire and ghost-contact collisions for one occupied cell.
+ *
+ * Collision priority is enforced here as:
+ * 1. Invincibility
+ * 2. Fire
+ * 3. Ghost contact
+ *
+ * @param {MapResource} mapResource - Map dimensions source.
+ * @param {CollisionScratch} scratch - Built occupancy data for this step.
+ * @param {number} cellIndex - Flat cell index being resolved.
+ * @param {Array<object> | null | undefined} collisionIntents - Shared intent buffer.
+ * @param {PlayerStore | null | undefined} playerStore - Player gameplay store.
+ * @param {HealthStore | null | undefined} healthStore - Health gameplay store.
+ * @param {GhostStore | null | undefined} ghostStore - Ghost gameplay store.
+ * @param {{ row: number, col: number }} reusableTile - Shared temporary tile object.
+ */
+function resolveDynamicCellCollisions(
+  mapResource,
+  scratch,
+  cellIndex,
+  collisionIntents,
+  playerStore,
+  healthStore,
+  ghostStore,
+  reusableTile,
+) {
+  const playerId = scratch.playerByCell[cellIndex];
+  const fireId = scratch.fireByCell[cellIndex];
+  const ghostCount = scratch.ghostCounts[cellIndex];
+  const tile = readTileFromCellIndex(mapResource, cellIndex, reusableTile);
+  const playerIsInvincible =
+    playerId !== -1 && isPlayerInvincible(playerStore, healthStore, playerId);
+
+  if (fireId !== -1) {
+    if (playerId !== -1 && !playerIsInvincible) {
+      appendCollisionIntent(collisionIntents, {
+        type: 'player-death',
+        entityId: playerId,
+        row: tile.row,
+        col: tile.col,
+        cause: 'fire',
+        sourceEntityId: fireId,
+      });
+    }
+
+    for (let ghostIndex = 0; ghostIndex < ghostCount; ghostIndex += 1) {
+      const ghostId = scratch.ghostIds[cellIndex * scratch.maxGhostsPerCell + ghostIndex];
+      const ghostState = ghostStore?.state?.[ghostId] ?? GHOST_STATE.NORMAL;
+      if (ghostState === GHOST_STATE.DEAD) {
+        continue;
+      }
+
+      appendCollisionIntent(collisionIntents, {
+        type: 'ghost-death',
+        entityId: ghostId,
+        row: tile.row,
+        col: tile.col,
+        cause: 'fire',
+        sourceEntityId: fireId,
+        ghostState,
+      });
+
+      // Marking the ghost dead immediately prevents the same lingering fire
+      // tile from emitting duplicate death intents on subsequent fixed steps.
+      if (ghostStore?.state) {
+        ghostStore.state[ghostId] = GHOST_STATE.DEAD;
+      }
+    }
+
+    return;
+  }
+
+  if (playerId === -1 || playerIsInvincible) {
+    return;
+  }
+
+  for (let ghostIndex = 0; ghostIndex < ghostCount; ghostIndex += 1) {
+    const ghostId = scratch.ghostIds[cellIndex * scratch.maxGhostsPerCell + ghostIndex];
+    const ghostState = ghostStore?.state?.[ghostId] ?? GHOST_STATE.NORMAL;
+    if (ghostState !== GHOST_STATE.NORMAL) {
+      continue;
+    }
+
+    appendCollisionIntent(collisionIntents, {
+      type: 'player-death',
+      entityId: playerId,
+      row: tile.row,
+      col: tile.col,
+      cause: 'ghost',
+      sourceEntityId: ghostId,
+      ghostState,
+    });
+    return;
+  }
+}
+
+/**
  * Create the collision system shell.
  *
  * @param {{
@@ -278,6 +453,7 @@ export function collectStaticPickup(mapResource, collisionIntents, entityId, row
  *   colliderResourceKey?: string,
  *   playerResourceKey?: string,
  *   healthResourceKey?: string,
+ *   ghostResourceKey?: string,
  *   collisionIntentsResourceKey?: string,
  *   requiredMask?: number,
  *   maxGhostsPerCell?: number,
@@ -290,11 +466,13 @@ export function createCollisionSystem(options = {}) {
   const colliderResourceKey = options.colliderResourceKey || 'collider';
   const playerResourceKey = options.playerResourceKey || 'player';
   const healthResourceKey = options.healthResourceKey || 'health';
+  const ghostResourceKey = options.ghostResourceKey || 'ghost';
   const collisionIntentsResourceKey = options.collisionIntentsResourceKey || 'collisionIntents';
   const requiredMask = options.requiredMask ?? COLLISION_ENTITY_REQUIRED_MASK;
   const maxGhostsPerCell = options.maxGhostsPerCell ?? DEFAULT_GHOST_SLOTS_PER_CELL;
   let scratch = null;
   const reusableTile = { row: 0, col: 0 };
+  const reusableCellTile = { row: 0, col: 0 };
 
   return {
     name: 'collision-system',
@@ -306,6 +484,7 @@ export function createCollisionSystem(options = {}) {
         colliderResourceKey,
         playerResourceKey,
         healthResourceKey,
+        ghostResourceKey,
       ],
       write: [collisionIntentsResourceKey],
     },
@@ -314,6 +493,9 @@ export function createCollisionSystem(options = {}) {
       const mapResource = world.getResource(mapResourceKey);
       const positionStore = world.getResource(positionResourceKey);
       const colliderStore = world.getResource(colliderResourceKey);
+      const playerStore = world.getResource(playerResourceKey);
+      const healthStore = world.getResource(healthResourceKey);
+      const ghostStore = world.getResource(ghostResourceKey);
       const collisionIntents = world.getResource(collisionIntentsResourceKey);
 
       // The shell is intentionally tolerant during early integration so tests
@@ -333,6 +515,14 @@ export function createCollisionSystem(options = {}) {
       );
 
       const entityIds = world.query(requiredMask);
+      buildDynamicOccupancy(
+        entityIds,
+        mapResource,
+        positionStore,
+        colliderStore,
+        scratch,
+        reusableTile,
+      );
 
       for (const entityId of entityIds) {
         // Only the player can collect static map pickups.
@@ -346,10 +536,26 @@ export function createCollisionSystem(options = {}) {
           continue;
         }
 
-        // Recording the player occupancy now keeps the scratch buffer aligned
-        // with the later dynamic-collision passes that will reuse this map.
-        scratch.playerByCell[cellIndex] = entityId;
         collectStaticPickup(mapResource, collisionIntents, entityId, tile.row, tile.col);
+      }
+
+      for (let cellIndex = 0; cellIndex < scratch.cellCount; cellIndex += 1) {
+        if (scratch.playerByCell[cellIndex] === -1 && scratch.fireByCell[cellIndex] === -1) {
+          if (scratch.ghostCounts[cellIndex] === 0) {
+            continue;
+          }
+        }
+
+        resolveDynamicCellCollisions(
+          mapResource,
+          scratch,
+          cellIndex,
+          collisionIntents,
+          playerStore,
+          healthStore,
+          ghostStore,
+          reusableCellTile,
+        );
       }
     },
   };

--- a/src/ecs/systems/collision-system.js
+++ b/src/ecs/systems/collision-system.js
@@ -1,10 +1,9 @@
 /*
- * B-04 entity collision system scaffold.
+ * B-04 entity collision system.
  *
- * This module owns the deterministic collision-resolution shell for Track B's
- * entity collision ticket. The current implementation establishes the helper
- * and system contract layer so later collision behavior can be added without
- * changing the public shape of the system.
+ * This module resolves deterministic gameplay collisions for the Track B
+ * collision ticket: static pickup collection, fire and ghost contact, and the
+ * occupancy constraints around the ghost house and bomb cells.
  *
  * Public API:
  * - COLLISION_ENTITY_REQUIRED_MASK: query mask for dynamic entities with tile positions.
@@ -16,7 +15,8 @@
  * - clearCollisionIntents(collisionIntents): empty the injected intent buffer in place.
  * - appendCollisionIntent(collisionIntents, intent): append one deterministic intent with monotonic order.
  * - isPlayerInvincible(playerStore, healthStore, entityId): resolve the current invincibility state.
- * - createCollisionSystem(options): create the logic-phase ECS system shell.
+ * - collectStaticPickup(mapResource, collisionIntents, entityId, row, col): resolve one static pickup tile.
+ * - createCollisionSystem(options): create the logic-phase ECS collision system.
  *
  * Implementation notes:
  * - The scratch buffers use typed arrays and sentinel values so the collision
@@ -25,9 +25,10 @@
  *   and the health flag store because the current codebase carries both
  *   representations; this keeps B-04 compatible without forcing a cross-ticket
  *   schema decision here.
- * - The system clears the injected collision intent array only when the core
- *   resources exist. If required resources are missing, the system returns
- *   early and does not mutate external state.
+ * - The system records collision intents but does not award score or mutate
+ *   player lives directly; later tickets consume these intents.
+ * - The one-time "bomb dropped on a shared ghost cell" push-back rule is not
+ *   approximated here because it needs an explicit placement-edge signal.
  */
 
 import { COMPONENT_MASK } from '../components/registry.js';
@@ -607,7 +608,7 @@ function resolveDynamicCellCollisions(
 }
 
 /**
- * Create the collision system shell.
+ * Create the logic-phase collision system.
  *
  * @param {{
  *   mapResourceKey?: string,
@@ -641,15 +642,8 @@ export function createCollisionSystem(options = {}) {
     name: 'collision-system',
     phase: 'logic',
     resourceCapabilities: {
-      read: [
-        mapResourceKey,
-        positionResourceKey,
-        colliderResourceKey,
-        playerResourceKey,
-        healthResourceKey,
-        ghostResourceKey,
-      ],
-      write: [collisionIntentsResourceKey],
+      read: [colliderResourceKey, playerResourceKey, healthResourceKey],
+      write: [mapResourceKey, positionResourceKey, ghostResourceKey, collisionIntentsResourceKey],
     },
     update(context) {
       const world = context.world;

--- a/src/ecs/systems/collision-system.js
+++ b/src/ecs/systems/collision-system.js
@@ -1,0 +1,356 @@
+/*
+ * B-04 entity collision system scaffold.
+ *
+ * This module owns the deterministic collision-resolution shell for Track B's
+ * entity collision ticket. The current implementation establishes the helper
+ * and system contract layer so later collision behavior can be added without
+ * changing the public shape of the system.
+ *
+ * Public API:
+ * - COLLISION_ENTITY_REQUIRED_MASK: query mask for dynamic entities with tile positions.
+ * - DEFAULT_GHOST_SLOTS_PER_CELL: scratch-buffer fan-out for ghost occupancy lanes.
+ * - tileToCellIndex(mapResource, row, col): convert a tile coordinate into a flat cell index.
+ * - readEntityTile(positionStore, entityId, outTile): copy one entity's tile into a reusable object.
+ * - createCollisionScratch(cellCount, maxGhostsPerCell): allocate reusable occupancy buffers.
+ * - resetCollisionScratch(scratch): clear a scratch buffer back to deterministic sentinels.
+ * - clearCollisionIntents(collisionIntents): empty the injected intent buffer in place.
+ * - appendCollisionIntent(collisionIntents, intent): append one deterministic intent with monotonic order.
+ * - isPlayerInvincible(playerStore, healthStore, entityId): resolve the current invincibility state.
+ * - createCollisionSystem(options): create the logic-phase ECS system shell.
+ *
+ * Implementation notes:
+ * - The scratch buffers use typed arrays and sentinel values so the collision
+ *   system can build O(1) occupancy maps without allocating inside hot loops.
+ * - The invincibility helper intentionally accepts both the player timer store
+ *   and the health flag store because the current codebase carries both
+ *   representations; this keeps B-04 compatible without forcing a cross-ticket
+ *   schema decision here.
+ * - The system clears the injected collision intent array only when the core
+ *   resources exist. If required resources are missing, the system returns
+ *   early and does not mutate external state.
+ */
+
+import { COMPONENT_MASK } from '../components/registry.js';
+import { COLLIDER_TYPE } from '../components/spatial.js';
+import { CELL_TYPE } from '../resources/constants.js';
+import { getCell, setCell } from '../resources/map-resource.js';
+
+/**
+ * Dynamic entities with tile positions are queried through position + collider.
+ * Additional collision sources may be read directly from other stores later,
+ * but that does not change the core query contract for moving entities.
+ */
+export const COLLISION_ENTITY_REQUIRED_MASK = COMPONENT_MASK.POSITION | COMPONENT_MASK.COLLIDER;
+
+/**
+ * Default occupancy fan-out for ghosts in one cell.
+ * Four is enough for the shipped game because the design caps the live ghost
+ * count at four, so one cell can never need more ghost slots than this.
+ */
+export const DEFAULT_GHOST_SLOTS_PER_CELL = 4;
+
+/**
+ * Convert a tile coordinate into the flat cell index used by occupancy buffers.
+ *
+ * @param {MapResource | null | undefined} mapResource - Map dimensions source.
+ * @param {number} row - Tile row to encode.
+ * @param {number} col - Tile col to encode.
+ * @returns {number} Flat cell index, or -1 when the tile is out of bounds.
+ */
+export function tileToCellIndex(mapResource, row, col) {
+  if (!mapResource) {
+    return -1;
+  }
+
+  if (row < 0 || row >= mapResource.rows || col < 0 || col >= mapResource.cols) {
+    return -1;
+  }
+
+  return row * mapResource.cols + col;
+}
+
+/**
+ * Copy one entity's current tile into a reusable output object.
+ *
+ * @param {PositionStore | null | undefined} positionStore - Position component store.
+ * @param {number} entityId - Entity slot to read.
+ * @param {{ row: number, col: number }} [outTile] - Reusable target object.
+ * @returns {{ row: number, col: number } | null} The populated tile object, or null when missing.
+ */
+export function readEntityTile(positionStore, entityId, outTile = { row: 0, col: 0 }) {
+  if (!positionStore) {
+    return null;
+  }
+
+  // Rounding keeps the helper stable for exact centered positions while still
+  // allowing a later refinement of the final in-transit collision semantics.
+  outTile.row = Math.round(positionStore.row[entityId]);
+  outTile.col = Math.round(positionStore.col[entityId]);
+  return outTile;
+}
+
+/**
+ * Allocate the reusable occupancy scratch buffers for one collision step.
+ *
+ * @param {number} cellCount - Total number of map cells.
+ * @param {number} [maxGhostsPerCell=DEFAULT_GHOST_SLOTS_PER_CELL] - Ghost lane count.
+ * @returns {CollisionScratch} Fresh scratch buffers sized for the map.
+ */
+export function createCollisionScratch(cellCount, maxGhostsPerCell = DEFAULT_GHOST_SLOTS_PER_CELL) {
+  return {
+    cellCount,
+    maxGhostsPerCell,
+    // Single-lane colliders use -1 to mean "no entity occupies this cell yet".
+    playerByCell: new Int32Array(cellCount).fill(-1),
+    bombByCell: new Int32Array(cellCount).fill(-1),
+    fireByCell: new Int32Array(cellCount).fill(-1),
+    // Ghosts need a compact fan-out lane because multiple ghosts can share one tile.
+    ghostCounts: new Uint8Array(cellCount),
+    ghostIds: new Int32Array(cellCount * maxGhostsPerCell).fill(-1),
+  };
+}
+
+/**
+ * Reset one scratch buffer back to deterministic sentinel defaults.
+ *
+ * @param {CollisionScratch} scratch - Reusable occupancy scratch buffer.
+ * @returns {CollisionScratch} The same scratch object for call chaining.
+ */
+export function resetCollisionScratch(scratch) {
+  scratch.playerByCell.fill(-1);
+  scratch.bombByCell.fill(-1);
+  scratch.fireByCell.fill(-1);
+  scratch.ghostCounts.fill(0);
+  scratch.ghostIds.fill(-1);
+  return scratch;
+}
+
+/**
+ * Empty the injected collision intent array in place.
+ *
+ * @param {Array<object> | null | undefined} collisionIntents - Shared step-local intent buffer.
+ * @returns {Array<object> | null} The same buffer when valid, otherwise null.
+ */
+export function clearCollisionIntents(collisionIntents) {
+  if (!Array.isArray(collisionIntents)) {
+    return null;
+  }
+
+  collisionIntents.length = 0;
+  return collisionIntents;
+}
+
+/**
+ * Append one deterministic collision intent into the injected array.
+ *
+ * @param {Array<object> | null | undefined} collisionIntents - Shared step-local intent buffer.
+ * @param {object} intent - Collision intent payload without the monotonic order.
+ * @returns {object | null} The appended record, or null when the buffer is invalid.
+ */
+export function appendCollisionIntent(collisionIntents, intent) {
+  if (!Array.isArray(collisionIntents)) {
+    return null;
+  }
+
+  const nextIntent = {
+    order: collisionIntents.length,
+    ...intent,
+  };
+  collisionIntents.push(nextIntent);
+  return nextIntent;
+}
+
+/**
+ * Resolve whether the player is currently protected from collision damage.
+ *
+ * @param {PlayerStore | null | undefined} playerStore - Player gameplay store.
+ * @param {HealthStore | null | undefined} healthStore - Health gameplay store.
+ * @param {number} entityId - Player entity slot to inspect.
+ * @returns {boolean} True when any supported invincibility source is active.
+ */
+export function isPlayerInvincible(playerStore, healthStore, entityId) {
+  if (healthStore?.isInvincible?.[entityId] === 1) {
+    return true;
+  }
+
+  return (playerStore?.invincibilityMs?.[entityId] || 0) > 0;
+}
+
+/**
+ * Ensure the system has a scratch buffer sized for the current map.
+ *
+ * @param {CollisionScratch | null} scratch - Existing closure-local scratch buffer.
+ * @param {number} cellCount - Current map cell count.
+ * @param {number} maxGhostsPerCell - Current ghost lane count.
+ * @returns {CollisionScratch} Reused or newly allocated scratch buffer.
+ */
+function ensureCollisionScratch(scratch, cellCount, maxGhostsPerCell) {
+  if (
+    !scratch ||
+    scratch.cellCount !== cellCount ||
+    scratch.maxGhostsPerCell !== maxGhostsPerCell
+  ) {
+    return createCollisionScratch(cellCount, maxGhostsPerCell);
+  }
+
+  return resetCollisionScratch(scratch);
+}
+
+/**
+ * Translate one static map power-up cell into the canonical gameplay type name.
+ *
+ * @param {number} cellType - Static map cell type at the player's tile.
+ * @returns {'bombPlus' | 'firePlus' | 'speedBoost' | null} Normalized power-up type.
+ */
+function readPowerUpTypeFromCell(cellType) {
+  if (cellType === CELL_TYPE.POWER_UP_BOMB) {
+    return 'bombPlus';
+  }
+
+  if (cellType === CELL_TYPE.POWER_UP_FIRE) {
+    return 'firePlus';
+  }
+
+  if (cellType === CELL_TYPE.POWER_UP_SPEED) {
+    return 'speedBoost';
+  }
+
+  return null;
+}
+
+/**
+ * Resolve and record collectible map-cell collisions for one player entity.
+ *
+ * The map is mutated immediately after a successful pickup so the same tile
+ * cannot emit the same collection intent again on the next fixed step.
+ *
+ * @param {MapResource} mapResource - Mutable static grid resource.
+ * @param {Array<object> | null | undefined} collisionIntents - Shared intent buffer.
+ * @param {number} entityId - Player entity that may collect the tile.
+ * @param {number} row - Player tile row.
+ * @param {number} col - Player tile col.
+ * @returns {object | null} The appended collection intent, or null when nothing collectible exists.
+ */
+export function collectStaticPickup(mapResource, collisionIntents, entityId, row, col) {
+  const cellType = getCell(mapResource, row, col);
+
+  if (cellType === CELL_TYPE.PELLET) {
+    setCell(mapResource, row, col, CELL_TYPE.EMPTY);
+    return appendCollisionIntent(collisionIntents, {
+      type: 'pellet-collected',
+      entityId,
+      row,
+      col,
+    });
+  }
+
+  if (cellType === CELL_TYPE.POWER_PELLET) {
+    setCell(mapResource, row, col, CELL_TYPE.EMPTY);
+    return appendCollisionIntent(collisionIntents, {
+      type: 'power-pellet-collected',
+      entityId,
+      row,
+      col,
+    });
+  }
+
+  const powerUpType = readPowerUpTypeFromCell(cellType);
+  if (!powerUpType) {
+    return null;
+  }
+
+  setCell(mapResource, row, col, CELL_TYPE.EMPTY);
+  return appendCollisionIntent(collisionIntents, {
+    type: 'power-up-collected',
+    entityId,
+    row,
+    col,
+    powerUpType,
+  });
+}
+
+/**
+ * Create the collision system shell.
+ *
+ * @param {{
+ *   mapResourceKey?: string,
+ *   positionResourceKey?: string,
+ *   colliderResourceKey?: string,
+ *   playerResourceKey?: string,
+ *   healthResourceKey?: string,
+ *   collisionIntentsResourceKey?: string,
+ *   requiredMask?: number,
+ *   maxGhostsPerCell?: number,
+ * }} [options] - Optional resource-key overrides for tests and later wiring.
+ * @returns {{ name: string, phase: string, resourceCapabilities: object, update: Function }} ECS registration.
+ */
+export function createCollisionSystem(options = {}) {
+  const mapResourceKey = options.mapResourceKey || 'mapResource';
+  const positionResourceKey = options.positionResourceKey || 'position';
+  const colliderResourceKey = options.colliderResourceKey || 'collider';
+  const playerResourceKey = options.playerResourceKey || 'player';
+  const healthResourceKey = options.healthResourceKey || 'health';
+  const collisionIntentsResourceKey = options.collisionIntentsResourceKey || 'collisionIntents';
+  const requiredMask = options.requiredMask ?? COLLISION_ENTITY_REQUIRED_MASK;
+  const maxGhostsPerCell = options.maxGhostsPerCell ?? DEFAULT_GHOST_SLOTS_PER_CELL;
+  let scratch = null;
+  const reusableTile = { row: 0, col: 0 };
+
+  return {
+    name: 'collision-system',
+    phase: 'logic',
+    resourceCapabilities: {
+      read: [
+        mapResourceKey,
+        positionResourceKey,
+        colliderResourceKey,
+        playerResourceKey,
+        healthResourceKey,
+      ],
+      write: [collisionIntentsResourceKey],
+    },
+    update(context) {
+      const world = context.world;
+      const mapResource = world.getResource(mapResourceKey);
+      const positionStore = world.getResource(positionResourceKey);
+      const colliderStore = world.getResource(colliderResourceKey);
+      const collisionIntents = world.getResource(collisionIntentsResourceKey);
+
+      // The shell is intentionally tolerant during early integration so tests
+      // and downstream systems can inject resources incrementally.
+      if (!mapResource || !positionStore || !colliderStore) {
+        return;
+      }
+
+      if (Array.isArray(collisionIntents)) {
+        clearCollisionIntents(collisionIntents);
+      }
+
+      scratch = ensureCollisionScratch(
+        scratch,
+        mapResource.rows * mapResource.cols,
+        maxGhostsPerCell,
+      );
+
+      const entityIds = world.query(requiredMask);
+
+      for (const entityId of entityIds) {
+        // Only the player can collect static map pickups.
+        if (colliderStore.type[entityId] !== COLLIDER_TYPE.PLAYER) {
+          continue;
+        }
+
+        const tile = readEntityTile(positionStore, entityId, reusableTile);
+        const cellIndex = tileToCellIndex(mapResource, tile.row, tile.col);
+        if (cellIndex < 0) {
+          continue;
+        }
+
+        // Recording the player occupancy now keeps the scratch buffer aligned
+        // with the later dynamic-collision passes that will reuse this map.
+        scratch.playerByCell[cellIndex] = entityId;
+        collectStaticPickup(mapResource, collisionIntents, entityId, tile.row, tile.col);
+      }
+    },
+  };
+}

--- a/tests/integration/gameplay/b-04-collision-system.test.js
+++ b/tests/integration/gameplay/b-04-collision-system.test.js
@@ -196,8 +196,30 @@ function createScriptedMovementSystem(applyMovement) {
   };
 }
 
+/**
+ * Create a tiny phase-recorder system so integration tests can assert dispatcher order.
+ *
+ * @param {'physics' | 'logic'} phase - ECS phase to record.
+ * @param {string[]} phaseLog - Mutable array collecting phase labels.
+ * @param {string} label - Label appended when the phase runs.
+ * @returns {{ name: string, phase: string, resourceCapabilities: object, update: Function }} ECS recorder system.
+ */
+function createPhaseRecorderSystem(phase, phaseLog, label) {
+  return {
+    name: `test-${label}-recorder`,
+    phase,
+    resourceCapabilities: {
+      read: [],
+      write: [],
+    },
+    update() {
+      phaseLog.push(label);
+    },
+  };
+}
+
 describe('B-04 collision system integration', () => {
-  it('resolves pickup and fire collisions after a physics movement step', () => {
+  it('runs physics before logic and resolves pickup and fire collisions from moved tiles', () => {
     const {
       colliderStore,
       collisionIntents,
@@ -207,6 +229,7 @@ describe('B-04 collision system integration', () => {
       positionStore,
       world,
     } = createCollisionIntegrationWorld([[1, 2, CELL_TYPE.EMPTY]]);
+    const phaseLog = [];
 
     const ghost = addCollisionEntity(
       world,
@@ -218,15 +241,18 @@ describe('B-04 collision system integration', () => {
     );
     addCollisionEntity(world, positionStore, colliderStore, COLLIDER_TYPE.FIRE, 1, 1);
 
+    world.registerSystem(createPhaseRecorderSystem('physics', phaseLog, 'physics'));
     world.registerSystem(
       createScriptedMovementSystem((store) => {
         moveEntity(store, player.id, 1, 1);
         moveEntity(store, ghost.id, 1, 1);
       }),
     );
+    world.registerSystem(createPhaseRecorderSystem('logic', phaseLog, 'logic'));
 
     world.runFixedStep({ dtMs: 16.6667 });
 
+    expect(phaseLog).toEqual(['physics', 'logic']);
     expect(collisionIntents).toEqual([
       {
         order: 0,
@@ -257,6 +283,184 @@ describe('B-04 collision system integration', () => {
     ]);
     expect(getCell(mapResource, 1, 1)).toBe(CELL_TYPE.EMPTY);
     expect(ghostStore.state[ghost.id]).toBe(GHOST_STATE.DEAD);
+  });
+
+  it('suppresses fire damage when the player is invincible', () => {
+    const { colliderStore, collisionIntents, healthStore, player, positionStore, world } =
+      createCollisionIntegrationWorld();
+
+    healthStore.isInvincible[player.id] = 1;
+    addCollisionEntity(world, positionStore, colliderStore, COLLIDER_TYPE.FIRE, 1, 2);
+
+    world.registerSystem(
+      createScriptedMovementSystem((store) => {
+        moveEntity(store, player.id, 1, 2);
+      }),
+    );
+
+    world.runFixedStep({ dtMs: 16.6667 });
+
+    expect(collisionIntents).toEqual([
+      {
+        order: 0,
+        type: 'pellet-collected',
+        entityId: player.id,
+        row: 1,
+        col: 2,
+      },
+    ]);
+  });
+
+  it('suppresses normal ghost contact when the player is invincible', () => {
+    const { colliderStore, collisionIntents, healthStore, player, positionStore, world } =
+      createCollisionIntegrationWorld();
+
+    healthStore.isInvincible[player.id] = 1;
+    addCollisionEntity(world, positionStore, colliderStore, COLLIDER_TYPE.GHOST, 1, 2);
+
+    world.registerSystem(
+      createScriptedMovementSystem((store) => {
+        moveEntity(store, player.id, 1, 2);
+      }),
+    );
+
+    world.runFixedStep({ dtMs: 16.6667 });
+
+    expect(collisionIntents).toEqual([
+      {
+        order: 0,
+        type: 'pellet-collected',
+        entityId: player.id,
+        row: 1,
+        col: 2,
+      },
+    ]);
+  });
+
+  it('treats stunned ghost contact as harmless', () => {
+    const { colliderStore, collisionIntents, ghostStore, player, positionStore, world } =
+      createCollisionIntegrationWorld();
+
+    const ghost = addCollisionEntity(
+      world,
+      positionStore,
+      colliderStore,
+      COLLIDER_TYPE.GHOST,
+      1,
+      3,
+    );
+    ghostStore.state[ghost.id] = GHOST_STATE.STUNNED;
+
+    world.registerSystem(
+      createScriptedMovementSystem((store) => {
+        moveEntity(store, player.id, 1, 3);
+      }),
+    );
+
+    world.runFixedStep({ dtMs: 16.6667 });
+
+    expect(collisionIntents).toEqual([
+      {
+        order: 0,
+        type: 'pellet-collected',
+        entityId: player.id,
+        row: 1,
+        col: 3,
+      },
+    ]);
+  });
+
+  it('records normal ghost contact after the physics move', () => {
+    const { colliderStore, collisionIntents, player, positionStore, world } =
+      createCollisionIntegrationWorld();
+
+    const ghost = addCollisionEntity(
+      world,
+      positionStore,
+      colliderStore,
+      COLLIDER_TYPE.GHOST,
+      1,
+      2,
+    );
+
+    world.registerSystem(
+      createScriptedMovementSystem((store) => {
+        moveEntity(store, player.id, 1, 2);
+      }),
+    );
+
+    world.runFixedStep({ dtMs: 16.6667 });
+
+    expect(collisionIntents).toEqual([
+      {
+        order: 0,
+        type: 'pellet-collected',
+        entityId: player.id,
+        row: 1,
+        col: 2,
+      },
+      {
+        order: 1,
+        type: 'player-death',
+        entityId: player.id,
+        row: 1,
+        col: 2,
+        cause: 'ghost',
+        sourceEntityId: ghost.id,
+        ghostState: GHOST_STATE.NORMAL,
+      },
+    ]);
+  });
+
+  it('collects a power pellet after the physics move', () => {
+    const { collisionIntents, mapResource, player, world } = createCollisionIntegrationWorld([
+      [1, 1, CELL_TYPE.POWER_PELLET],
+    ]);
+
+    world.registerSystem(
+      createScriptedMovementSystem((store) => {
+        moveEntity(store, player.id, 1, 1);
+      }),
+    );
+
+    world.runFixedStep({ dtMs: 16.6667 });
+
+    expect(collisionIntents).toEqual([
+      {
+        order: 0,
+        type: 'power-pellet-collected',
+        entityId: player.id,
+        row: 1,
+        col: 1,
+      },
+    ]);
+    expect(getCell(mapResource, 1, 1)).toBe(CELL_TYPE.EMPTY);
+  });
+
+  it('collects a power-up after the physics move', () => {
+    const { collisionIntents, mapResource, player, world } = createCollisionIntegrationWorld([
+      [1, 1, CELL_TYPE.POWER_UP_FIRE],
+    ]);
+
+    world.registerSystem(
+      createScriptedMovementSystem((store) => {
+        moveEntity(store, player.id, 1, 1);
+      }),
+    );
+
+    world.runFixedStep({ dtMs: 16.6667 });
+
+    expect(collisionIntents).toEqual([
+      {
+        order: 0,
+        type: 'power-up-collected',
+        entityId: player.id,
+        row: 1,
+        col: 1,
+        powerUpType: 'firePlus',
+      },
+    ]);
+    expect(getCell(mapResource, 1, 1)).toBe(CELL_TYPE.EMPTY);
   });
 
   it('reverts illegal ghost-house and bomb-cell entries before collision resolution', () => {
@@ -293,6 +497,85 @@ describe('B-04 collision system integration', () => {
     expect(positionStore.col[ghost.id]).toBe(1);
     expect(positionStore.targetRow[ghost.id]).toBe(1);
     expect(positionStore.targetCol[ghost.id]).toBe(1);
+    expect(collisionIntents).toEqual([]);
+  });
+
+  it('allows dead ghosts to re-enter the ghost house and live ghosts to exit it', () => {
+    const { colliderStore, collisionIntents, ghostStore, player, positionStore, world } =
+      createCollisionIntegrationWorld([
+        [1, 1, CELL_TYPE.EMPTY],
+        [2, 2, CELL_TYPE.EMPTY],
+      ]);
+
+    placeEntity(positionStore, player.id, 1, 1);
+    const deadGhost = addCollisionEntity(
+      world,
+      positionStore,
+      colliderStore,
+      COLLIDER_TYPE.GHOST,
+      2,
+      2,
+    );
+    ghostStore.state[deadGhost.id] = GHOST_STATE.DEAD;
+    const exitingGhost = addCollisionEntity(
+      world,
+      positionStore,
+      colliderStore,
+      COLLIDER_TYPE.GHOST,
+      3,
+      2,
+    );
+
+    world.registerSystem(
+      createScriptedMovementSystem((store) => {
+        moveEntity(store, deadGhost.id, 3, 2);
+        moveEntity(store, exitingGhost.id, 2, 2);
+      }),
+    );
+
+    world.runFixedStep({ dtMs: 16.6667 });
+
+    expect(positionStore.row[deadGhost.id]).toBe(3);
+    expect(positionStore.col[deadGhost.id]).toBe(2);
+    expect(positionStore.row[exitingGhost.id]).toBe(2);
+    expect(positionStore.col[exitingGhost.id]).toBe(2);
+    expect(collisionIntents).toEqual([]);
+  });
+
+  it('pushes a ghost one cell in its travel direction when a bomb is dropped on the shared tile', () => {
+    const { colliderStore, collisionIntents, player, positionStore, world } =
+      createCollisionIntegrationWorld([
+        [1, 2, CELL_TYPE.EMPTY],
+        [1, 3, CELL_TYPE.EMPTY],
+      ]);
+
+    placeEntity(positionStore, player.id, 2, 2);
+    const ghost = addCollisionEntity(
+      world,
+      positionStore,
+      colliderStore,
+      COLLIDER_TYPE.GHOST,
+      1,
+      2,
+    );
+    const bomb = addCollisionEntity(world, positionStore, colliderStore, COLLIDER_TYPE.BOMB, 1, 2);
+
+    world.registerSystem(
+      createScriptedMovementSystem((store) => {
+        moveEntity(store, ghost.id, 1, 2);
+        store.prevCol[ghost.id] = 1;
+        moveEntity(store, bomb.id, 1, 2);
+        store.prevRow[bomb.id] = 0;
+        store.prevCol[bomb.id] = 0;
+      }),
+    );
+
+    world.runFixedStep({ dtMs: 16.6667 });
+
+    expect(positionStore.row[ghost.id]).toBe(1);
+    expect(positionStore.col[ghost.id]).toBe(3);
+    expect(positionStore.targetRow[ghost.id]).toBe(1);
+    expect(positionStore.targetCol[ghost.id]).toBe(3);
     expect(collisionIntents).toEqual([]);
   });
 });

--- a/tests/integration/gameplay/b-04-collision-system.test.js
+++ b/tests/integration/gameplay/b-04-collision-system.test.js
@@ -1,0 +1,298 @@
+/*
+ * Test: b-04-collision-system.test.js
+ * Purpose: Covers collision-system behavior when it runs as a registered ECS logic system after a physics step.
+ * Public API: N/A (test module).
+ * Implementation Notes:
+ * - These tests use the real World phase dispatcher so they catch regressions in phase ordering and resource access.
+ * - The movement stub deliberately runs in the physics phase while the collision system is registered separately in logic.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { createGhostStore, createPlayerStore } from '../../../src/ecs/components/actors.js';
+import { COMPONENT_MASK } from '../../../src/ecs/components/registry.js';
+import {
+  COLLIDER_TYPE,
+  createColliderStore,
+  createPositionStore,
+} from '../../../src/ecs/components/spatial.js';
+import { createHealthStore } from '../../../src/ecs/components/stats.js';
+import { CELL_TYPE, GHOST_STATE } from '../../../src/ecs/resources/constants.js';
+import { createMapResource, getCell } from '../../../src/ecs/resources/map-resource.js';
+import {
+  COLLISION_ENTITY_REQUIRED_MASK,
+  createCollisionSystem,
+} from '../../../src/ecs/systems/collision-system.js';
+import { World } from '../../../src/ecs/world/world.js';
+
+/**
+ * Build a compact valid map for collision-system integration tests.
+ *
+ * @param {Array<[number, number, number]>} [overrides] - Optional [row, col, cellType] edits.
+ * @returns {object} Raw map JSON object that passes D-03 semantic validation.
+ */
+function createCollisionRawMap(overrides = []) {
+  const rawMap = {
+    level: 88,
+    metadata: {
+      name: 'Collision Integration Harness',
+      timerSeconds: 120,
+      maxGhosts: 2,
+      ghostSpeed: 4.0,
+      activeGhostTypes: [0, 1],
+    },
+    dimensions: { rows: 5, columns: 5 },
+    grid: [
+      [1, 1, 1, 1, 1],
+      [1, 3, 3, 3, 1],
+      [1, 3, 6, 3, 1],
+      [1, 3, 5, 3, 1],
+      [1, 1, 1, 1, 1],
+    ],
+    spawn: {
+      player: { row: 2, col: 2 },
+      ghostHouse: {
+        topRow: 3,
+        bottomRow: 3,
+        leftCol: 2,
+        rightCol: 2,
+      },
+      ghostSpawnPoint: { row: 3, col: 2 },
+    },
+  };
+
+  // Tests override only the tiles they need so the harness stays small and explicit.
+  for (const [row, col, cellType] of overrides) {
+    rawMap.grid[row][col] = cellType;
+  }
+
+  return rawMap;
+}
+
+/**
+ * Place one entity directly on a chosen tile and keep previous/target fields aligned.
+ *
+ * @param {PositionStore} positionStore - Mutable position store.
+ * @param {number} entityId - Entity slot to update.
+ * @param {number} row - Tile row to occupy.
+ * @param {number} col - Tile col to occupy.
+ */
+function placeEntity(positionStore, entityId, row, col) {
+  positionStore.prevRow[entityId] = row;
+  positionStore.prevCol[entityId] = col;
+  positionStore.row[entityId] = row;
+  positionStore.col[entityId] = col;
+  positionStore.targetRow[entityId] = row;
+  positionStore.targetCol[entityId] = col;
+}
+
+/**
+ * Move one entity in a physics-step style update by preserving the previous tile first.
+ *
+ * @param {PositionStore} positionStore - Mutable position store.
+ * @param {number} entityId - Entity slot to update.
+ * @param {number} row - New tile row.
+ * @param {number} col - New tile col.
+ */
+function moveEntity(positionStore, entityId, row, col) {
+  positionStore.prevRow[entityId] = positionStore.row[entityId];
+  positionStore.prevCol[entityId] = positionStore.col[entityId];
+  positionStore.row[entityId] = row;
+  positionStore.col[entityId] = col;
+  positionStore.targetRow[entityId] = row;
+  positionStore.targetCol[entityId] = col;
+}
+
+/**
+ * Create one extra collision entity and place it on a chosen tile.
+ *
+ * @param {World} world - ECS world receiving the entity.
+ * @param {PositionStore} positionStore - Mutable position store.
+ * @param {ColliderStore} colliderStore - Mutable collider store.
+ * @param {number} colliderType - Canonical collider type to assign.
+ * @param {number} row - Tile row to occupy.
+ * @param {number} col - Tile col to occupy.
+ * @returns {{ id: number, generation: number }} Created entity handle.
+ */
+function addCollisionEntity(world, positionStore, colliderStore, colliderType, row, col) {
+  const entity = world.createEntity(COLLISION_ENTITY_REQUIRED_MASK);
+
+  colliderStore.type[entity.id] = colliderType;
+  placeEntity(positionStore, entity.id, row, col);
+
+  return entity;
+}
+
+/**
+ * Build a world harness with the real collision system registered.
+ *
+ * @param {Array<[number, number, number]>} [mapOverrides] - Optional map cell overrides.
+ * @returns {{
+ *   colliderStore: ColliderStore,
+ *   collisionIntents: Array<object>,
+ *   ghostStore: GhostStore,
+ *   healthStore: HealthStore,
+ *   mapResource: MapResource,
+ *   player: { id: number, generation: number },
+ *   playerStore: PlayerStore,
+ *   positionStore: PositionStore,
+ *   world: World,
+ * }} Ready-to-run integration harness.
+ */
+function createCollisionIntegrationWorld(mapOverrides = []) {
+  const world = new World();
+  const mapResource = createMapResource(createCollisionRawMap(mapOverrides));
+  const positionStore = createPositionStore(8);
+  const colliderStore = createColliderStore(8);
+  const playerStore = createPlayerStore(8);
+  const ghostStore = createGhostStore(8);
+  const healthStore = createHealthStore(8);
+  const collisionIntents = [];
+  const player = world.createEntity(COMPONENT_MASK.POSITION | COMPONENT_MASK.COLLIDER);
+
+  colliderStore.type[player.id] = COLLIDER_TYPE.PLAYER;
+  placeEntity(positionStore, player.id, mapResource.playerSpawnRow, mapResource.playerSpawnCol);
+
+  world.setResource('mapResource', mapResource);
+  world.setResource('position', positionStore);
+  world.setResource('collider', colliderStore);
+  world.setResource('player', playerStore);
+  world.setResource('ghost', ghostStore);
+  world.setResource('health', healthStore);
+  world.setResource('collisionIntents', collisionIntents);
+  world.registerSystem(createCollisionSystem());
+
+  return {
+    colliderStore,
+    collisionIntents,
+    ghostStore,
+    healthStore,
+    mapResource,
+    player,
+    playerStore,
+    positionStore,
+    world,
+  };
+}
+
+/**
+ * Create a small scripted physics system for fixed-step integration tests.
+ *
+ * @param {(positionStore: PositionStore) => void} applyMovement - Physics-phase movement script.
+ * @returns {{ name: string, phase: string, resourceCapabilities: object, update: Function }} ECS physics system.
+ */
+function createScriptedMovementSystem(applyMovement) {
+  return {
+    name: 'test-scripted-movement',
+    phase: 'physics',
+    resourceCapabilities: {
+      read: ['position'],
+      write: ['position'],
+    },
+    update(context) {
+      const positionStore = context.world.getResource('position');
+      applyMovement(positionStore);
+    },
+  };
+}
+
+describe('B-04 collision system integration', () => {
+  it('resolves pickup and fire collisions after a physics movement step', () => {
+    const {
+      colliderStore,
+      collisionIntents,
+      ghostStore,
+      mapResource,
+      player,
+      positionStore,
+      world,
+    } = createCollisionIntegrationWorld([[1, 2, CELL_TYPE.EMPTY]]);
+
+    const ghost = addCollisionEntity(
+      world,
+      positionStore,
+      colliderStore,
+      COLLIDER_TYPE.GHOST,
+      1,
+      2,
+    );
+    addCollisionEntity(world, positionStore, colliderStore, COLLIDER_TYPE.FIRE, 1, 1);
+
+    world.registerSystem(
+      createScriptedMovementSystem((store) => {
+        moveEntity(store, player.id, 1, 1);
+        moveEntity(store, ghost.id, 1, 1);
+      }),
+    );
+
+    world.runFixedStep({ dtMs: 16.6667 });
+
+    expect(collisionIntents).toEqual([
+      {
+        order: 0,
+        type: 'pellet-collected',
+        entityId: player.id,
+        row: 1,
+        col: 1,
+      },
+      {
+        order: 1,
+        type: 'player-death',
+        entityId: player.id,
+        row: 1,
+        col: 1,
+        cause: 'fire',
+        sourceEntityId: 2,
+      },
+      {
+        order: 2,
+        type: 'ghost-death',
+        entityId: ghost.id,
+        row: 1,
+        col: 1,
+        cause: 'fire',
+        sourceEntityId: 2,
+        ghostState: GHOST_STATE.NORMAL,
+      },
+    ]);
+    expect(getCell(mapResource, 1, 1)).toBe(CELL_TYPE.EMPTY);
+    expect(ghostStore.state[ghost.id]).toBe(GHOST_STATE.DEAD);
+  });
+
+  it('reverts illegal ghost-house and bomb-cell entries before collision resolution', () => {
+    const { colliderStore, collisionIntents, player, positionStore, world } =
+      createCollisionIntegrationWorld([
+        [1, 2, CELL_TYPE.EMPTY],
+        [1, 3, CELL_TYPE.EMPTY],
+      ]);
+
+    const ghost = addCollisionEntity(
+      world,
+      positionStore,
+      colliderStore,
+      COLLIDER_TYPE.GHOST,
+      1,
+      1,
+    );
+    addCollisionEntity(world, positionStore, colliderStore, COLLIDER_TYPE.BOMB, 1, 2);
+
+    world.registerSystem(
+      createScriptedMovementSystem((store) => {
+        moveEntity(store, player.id, 3, 2);
+        moveEntity(store, ghost.id, 1, 2);
+      }),
+    );
+
+    world.runFixedStep({ dtMs: 16.6667 });
+
+    expect(positionStore.row[player.id]).toBe(2);
+    expect(positionStore.col[player.id]).toBe(2);
+    expect(positionStore.targetRow[player.id]).toBe(2);
+    expect(positionStore.targetCol[player.id]).toBe(2);
+    expect(positionStore.row[ghost.id]).toBe(1);
+    expect(positionStore.col[ghost.id]).toBe(1);
+    expect(positionStore.targetRow[ghost.id]).toBe(1);
+    expect(positionStore.targetCol[ghost.id]).toBe(1);
+    expect(collisionIntents).toEqual([]);
+  });
+});

--- a/tests/unit/systems/collision-system.test.js
+++ b/tests/unit/systems/collision-system.test.js
@@ -153,6 +153,25 @@ function setEntityTile(positionStore, entityId, row, col) {
 }
 
 /**
+ * Set both the previous and current tile for one entity.
+ *
+ * This is useful for rules that depend on whether the entity entered a tile
+ * this step versus already occupying it on the prior step.
+ *
+ * @param {PositionStore} positionStore - Mutable position store.
+ * @param {number} entityId - Entity slot to update.
+ * @param {number} prevRow - Previous tile row.
+ * @param {number} prevCol - Previous tile col.
+ * @param {number} row - Current tile row.
+ * @param {number} col - Current tile col.
+ */
+function setEntityPath(positionStore, entityId, prevRow, prevCol, row, col) {
+  positionStore.prevRow[entityId] = prevRow;
+  positionStore.prevCol[entityId] = prevCol;
+  setEntityTile(positionStore, entityId, row, col);
+}
+
+/**
  * Create one extra collision entity and place it on a chosen tile.
  *
  * @param {World} world - ECS world receiving the entity.
@@ -816,6 +835,174 @@ describe('collision-system update shell', () => {
       },
     ]);
     expect(ghostStore.state[ghost.id]).toBe(GHOST_STATE.DEAD);
+  });
+
+  it('reverts the player to the previous tile when the player occupies a ghost-house tile', () => {
+    const { collisionIntents, player, positionStore, system, world } = createCollisionHarness([
+      [1, 1, CELL_TYPE.EMPTY],
+    ]);
+
+    setEntityPath(positionStore, player.id, 2, 2, 3, 2);
+
+    system.update({
+      dtMs: 16.6667,
+      frame: 0,
+      world,
+    });
+
+    expect(positionStore.row[player.id]).toBe(2);
+    expect(positionStore.col[player.id]).toBe(2);
+    expect(positionStore.targetRow[player.id]).toBe(2);
+    expect(positionStore.targetCol[player.id]).toBe(2);
+    expect(collisionIntents).toEqual([]);
+  });
+
+  it('allows a dead ghost to enter the ghost house from outside', () => {
+    const { colliderStore, collisionIntents, ghostStore, player, positionStore, system, world } =
+      createCollisionHarness([[1, 1, CELL_TYPE.EMPTY]]);
+
+    setEntityTile(positionStore, player.id, 1, 1);
+    const ghost = addCollisionEntity(
+      world,
+      positionStore,
+      colliderStore,
+      COLLIDER_TYPE.GHOST,
+      3,
+      2,
+    );
+    setEntityPath(positionStore, ghost.id, 2, 2, 3, 2);
+    ghostStore.state[ghost.id] = GHOST_STATE.DEAD;
+
+    system.update({
+      dtMs: 16.6667,
+      frame: 0,
+      world,
+    });
+
+    expect(positionStore.row[ghost.id]).toBe(3);
+    expect(positionStore.col[ghost.id]).toBe(2);
+    expect(collisionIntents).toEqual([]);
+  });
+
+  it('reverts a non-dead ghost that tries to enter the ghost house from outside', () => {
+    const { colliderStore, collisionIntents, player, positionStore, system, world } =
+      createCollisionHarness([[1, 1, CELL_TYPE.EMPTY]]);
+
+    setEntityTile(positionStore, player.id, 1, 1);
+    const ghost = addCollisionEntity(
+      world,
+      positionStore,
+      colliderStore,
+      COLLIDER_TYPE.GHOST,
+      3,
+      2,
+    );
+    setEntityPath(positionStore, ghost.id, 2, 2, 3, 2);
+
+    system.update({
+      dtMs: 16.6667,
+      frame: 0,
+      world,
+    });
+
+    expect(positionStore.row[ghost.id]).toBe(2);
+    expect(positionStore.col[ghost.id]).toBe(2);
+    expect(positionStore.targetRow[ghost.id]).toBe(2);
+    expect(positionStore.targetCol[ghost.id]).toBe(2);
+    expect(collisionIntents).toEqual([]);
+  });
+
+  it('allows a ghost to exit the ghost house', () => {
+    const { colliderStore, collisionIntents, player, positionStore, system, world } =
+      createCollisionHarness([
+        [1, 1, CELL_TYPE.EMPTY],
+        [2, 2, CELL_TYPE.EMPTY],
+      ]);
+
+    setEntityTile(positionStore, player.id, 1, 1);
+    const ghost = addCollisionEntity(
+      world,
+      positionStore,
+      colliderStore,
+      COLLIDER_TYPE.GHOST,
+      2,
+      2,
+    );
+    setEntityPath(positionStore, ghost.id, 3, 2, 2, 2);
+
+    system.update({
+      dtMs: 16.6667,
+      frame: 0,
+      world,
+    });
+
+    expect(positionStore.row[ghost.id]).toBe(2);
+    expect(positionStore.col[ghost.id]).toBe(2);
+    expect(collisionIntents).toEqual([]);
+  });
+
+  it('reverts a ghost that enters a bomb cell from another tile', () => {
+    const { colliderStore, collisionIntents, player, positionStore, system, world } =
+      createCollisionHarness([
+        [1, 2, CELL_TYPE.EMPTY],
+        [1, 3, CELL_TYPE.EMPTY],
+      ]);
+
+    setEntityTile(positionStore, player.id, 1, 3);
+    const ghost = addCollisionEntity(
+      world,
+      positionStore,
+      colliderStore,
+      COLLIDER_TYPE.GHOST,
+      1,
+      2,
+    );
+    setEntityPath(positionStore, ghost.id, 1, 1, 1, 2);
+    addCollisionEntity(world, positionStore, colliderStore, COLLIDER_TYPE.BOMB, 1, 2);
+
+    system.update({
+      dtMs: 16.6667,
+      frame: 0,
+      world,
+    });
+
+    expect(positionStore.row[ghost.id]).toBe(1);
+    expect(positionStore.col[ghost.id]).toBe(1);
+    expect(positionStore.targetRow[ghost.id]).toBe(1);
+    expect(positionStore.targetCol[ghost.id]).toBe(1);
+    expect(collisionIntents).toEqual([]);
+  });
+
+  it('allows a ghost to remain on the same bomb cell when the previous tile matches the current tile', () => {
+    const { colliderStore, collisionIntents, player, positionStore, system, world } =
+      createCollisionHarness([
+        [1, 2, CELL_TYPE.EMPTY],
+        [1, 3, CELL_TYPE.EMPTY],
+      ]);
+
+    setEntityTile(positionStore, player.id, 1, 3);
+    const ghost = addCollisionEntity(
+      world,
+      positionStore,
+      colliderStore,
+      COLLIDER_TYPE.GHOST,
+      1,
+      2,
+    );
+    setEntityPath(positionStore, ghost.id, 1, 2, 1, 2);
+    addCollisionEntity(world, positionStore, colliderStore, COLLIDER_TYPE.BOMB, 1, 2);
+
+    system.update({
+      dtMs: 16.6667,
+      frame: 0,
+      world,
+    });
+
+    expect(positionStore.row[ghost.id]).toBe(1);
+    expect(positionStore.col[ghost.id]).toBe(2);
+    expect(positionStore.targetRow[ghost.id]).toBe(1);
+    expect(positionStore.targetCol[ghost.id]).toBe(2);
+    expect(collisionIntents).toEqual([]);
   });
 
   it('uses a real map resource fixture so the harness stays aligned with D-03 semantics', () => {

--- a/tests/unit/systems/collision-system.test.js
+++ b/tests/unit/systems/collision-system.test.js
@@ -110,6 +110,8 @@ function createCollisionHarness(mapOverrides = []) {
   // The harness keeps the player centered on the declared spawn tile.
   positionStore.row[player.id] = mapResource.playerSpawnRow;
   positionStore.col[player.id] = mapResource.playerSpawnCol;
+  positionStore.prevRow[player.id] = mapResource.playerSpawnRow;
+  positionStore.prevCol[player.id] = mapResource.playerSpawnCol;
   positionStore.targetRow[player.id] = mapResource.playerSpawnRow;
   positionStore.targetCol[player.id] = mapResource.playerSpawnCol;
   colliderStore.type[player.id] = COLLIDER_TYPE.PLAYER;
@@ -145,6 +147,8 @@ function createCollisionHarness(mapOverrides = []) {
  * @param {number} col - Tile col to occupy.
  */
 function setEntityTile(positionStore, entityId, row, col) {
+  positionStore.prevRow[entityId] = row;
+  positionStore.prevCol[entityId] = col;
   positionStore.row[entityId] = row;
   positionStore.col[entityId] = col;
   positionStore.targetRow[entityId] = row;
@@ -167,7 +171,10 @@ function setEntityTile(positionStore, entityId, row, col) {
 function setEntityPath(positionStore, entityId, prevRow, prevCol, row, col) {
   positionStore.prevRow[entityId] = prevRow;
   positionStore.prevCol[entityId] = prevCol;
-  setEntityTile(positionStore, entityId, row, col);
+  positionStore.row[entityId] = row;
+  positionStore.col[entityId] = col;
+  positionStore.targetRow[entityId] = row;
+  positionStore.targetCol[entityId] = col;
 }
 
 /**
@@ -270,6 +277,7 @@ describe('collision-system helpers', () => {
 
     scratch.playerByCell[0] = 7;
     scratch.bombByCell[1] = 8;
+    scratch.droppedBombByCell[1] = 8;
     scratch.fireByCell[2] = 9;
     scratch.ghostCounts[3] = 2;
     scratch.ghostIds[4] = 10;
@@ -279,6 +287,7 @@ describe('collision-system helpers', () => {
     expect(returnedScratch).toBe(scratch);
     expect([...scratch.playerByCell]).toEqual([-1, -1, -1, -1]);
     expect([...scratch.bombByCell]).toEqual([-1, -1, -1, -1]);
+    expect([...scratch.droppedBombByCell]).toEqual([-1, -1, -1, -1]);
     expect([...scratch.fireByCell]).toEqual([-1, -1, -1, -1]);
     expect([...scratch.ghostCounts]).toEqual([0, 0, 0, 0]);
     expect([...scratch.ghostIds]).toEqual([-1, -1, -1, -1, -1, -1, -1, -1]);
@@ -958,7 +967,7 @@ describe('collision-system update shell', () => {
         [1, 3, CELL_TYPE.EMPTY],
       ]);
 
-    setEntityTile(positionStore, player.id, 1, 3);
+    setEntityTile(positionStore, player.id, 2, 2);
     const ghost = addCollisionEntity(
       world,
       positionStore,
@@ -983,14 +992,14 @@ describe('collision-system update shell', () => {
     expect(collisionIntents).toEqual([]);
   });
 
-  it('allows a ghost to remain on the same bomb cell when the previous tile matches the current tile', () => {
+  it('pushes a ghost one cell in its travel direction when a bomb is dropped on the shared tile', () => {
     const { colliderStore, collisionIntents, player, positionStore, system, world } =
       createCollisionHarness([
         [1, 2, CELL_TYPE.EMPTY],
         [1, 3, CELL_TYPE.EMPTY],
       ]);
 
-    setEntityTile(positionStore, player.id, 1, 3);
+    setEntityTile(positionStore, player.id, 2, 2);
     const ghost = addCollisionEntity(
       world,
       positionStore,
@@ -999,8 +1008,9 @@ describe('collision-system update shell', () => {
       1,
       2,
     );
-    setEntityPath(positionStore, ghost.id, 1, 2, 1, 2);
-    addCollisionEntity(world, positionStore, colliderStore, COLLIDER_TYPE.BOMB, 1, 2);
+    setEntityPath(positionStore, ghost.id, 1, 1, 1, 2);
+    const bomb = addCollisionEntity(world, positionStore, colliderStore, COLLIDER_TYPE.BOMB, 1, 2);
+    setEntityPath(positionStore, bomb.id, 0, 0, 1, 2);
 
     system.update({
       dtMs: 16.6667,
@@ -1009,9 +1019,9 @@ describe('collision-system update shell', () => {
     });
 
     expect(positionStore.row[ghost.id]).toBe(1);
-    expect(positionStore.col[ghost.id]).toBe(2);
+    expect(positionStore.col[ghost.id]).toBe(3);
     expect(positionStore.targetRow[ghost.id]).toBe(1);
-    expect(positionStore.targetCol[ghost.id]).toBe(2);
+    expect(positionStore.targetCol[ghost.id]).toBe(3);
     expect(collisionIntents).toEqual([]);
   });
 

--- a/tests/unit/systems/collision-system.test.js
+++ b/tests/unit/systems/collision-system.test.js
@@ -1,0 +1,489 @@
+/**
+ * Unit tests for the B-04 collision-system scaffold.
+ *
+ * These tests prove the helper and system-shell contract: logic-phase
+ * registration, deterministic helper behavior, reusable scratch buffers, and
+ * the ability to inject a plain collision intent array without requiring a
+ * dedicated resource module yet.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { createPlayerStore } from '../../../src/ecs/components/actors.js';
+import { COMPONENT_MASK } from '../../../src/ecs/components/registry.js';
+import {
+  COLLIDER_TYPE,
+  createColliderStore,
+  createPositionStore,
+} from '../../../src/ecs/components/spatial.js';
+import { createHealthStore } from '../../../src/ecs/components/stats.js';
+import { CELL_TYPE } from '../../../src/ecs/resources/constants.js';
+import { createMapResource, getCell } from '../../../src/ecs/resources/map-resource.js';
+import {
+  appendCollisionIntent,
+  COLLISION_ENTITY_REQUIRED_MASK,
+  clearCollisionIntents,
+  collectStaticPickup,
+  createCollisionScratch,
+  createCollisionSystem,
+  DEFAULT_GHOST_SLOTS_PER_CELL,
+  isPlayerInvincible,
+  readEntityTile,
+  resetCollisionScratch,
+  tileToCellIndex,
+} from '../../../src/ecs/systems/collision-system.js';
+import { World } from '../../../src/ecs/world/world.js';
+
+/**
+ * Build a compact valid map for collision-system unit tests.
+ *
+ * @param {Array<[number, number, number]>} [overrides] - Optional [row, col, cellType] edits.
+ * @returns {object} Raw map JSON object that passes D-03 semantic validation.
+ */
+function createCollisionRawMap(overrides = []) {
+  const rawMap = {
+    level: 77,
+    metadata: {
+      name: 'Collision Harness',
+      timerSeconds: 120,
+      maxGhosts: 2,
+      ghostSpeed: 4.0,
+      activeGhostTypes: [0, 1],
+    },
+    dimensions: { rows: 5, columns: 5 },
+    grid: [
+      [1, 1, 1, 1, 1],
+      [1, 3, 3, 3, 1],
+      [1, 3, 6, 3, 1],
+      [1, 3, 5, 3, 1],
+      [1, 1, 1, 1, 1],
+    ],
+    spawn: {
+      player: { row: 2, col: 2 },
+      ghostHouse: {
+        topRow: 3,
+        bottomRow: 3,
+        leftCol: 2,
+        rightCol: 2,
+      },
+      ghostSpawnPoint: { row: 3, col: 2 },
+    },
+  };
+
+  // Each override lets one test change exactly the tile it needs without
+  // duplicating the fixture structure in multiple test bodies.
+  for (const [row, col, cellType] of overrides) {
+    rawMap.grid[row][col] = cellType;
+  }
+
+  return rawMap;
+}
+
+/**
+ * Build a minimal world harness for the collision-system shell.
+ *
+ * @param {Array<[number, number, number]>} [mapOverrides] - Optional map cell overrides.
+ * @returns {{
+ *   colliderStore: ColliderStore,
+ *   collisionIntents: Array<object>,
+ *   healthStore: HealthStore,
+ *   mapResource: MapResource,
+ *   player: { id: number, generation: number },
+ *   playerStore: PlayerStore,
+ *   positionStore: PositionStore,
+ *   system: { update: Function, phase: string, resourceCapabilities: object },
+ *   world: World,
+ * }} Ready-to-run collision harness.
+ */
+function createCollisionHarness(mapOverrides = []) {
+  const world = new World();
+  const system = createCollisionSystem();
+  const mapResource = createMapResource(createCollisionRawMap(mapOverrides));
+  const positionStore = createPositionStore(8);
+  const colliderStore = createColliderStore(8);
+  const playerStore = createPlayerStore(8);
+  const healthStore = createHealthStore(8);
+  const collisionIntents = [{ type: 'stale-intent' }];
+  const player = world.createEntity(COLLISION_ENTITY_REQUIRED_MASK);
+
+  // The harness keeps the player centered on the declared spawn tile.
+  positionStore.row[player.id] = mapResource.playerSpawnRow;
+  positionStore.col[player.id] = mapResource.playerSpawnCol;
+  positionStore.targetRow[player.id] = mapResource.playerSpawnRow;
+  positionStore.targetCol[player.id] = mapResource.playerSpawnCol;
+  colliderStore.type[player.id] = COLLIDER_TYPE.PLAYER;
+
+  world.setResource('mapResource', mapResource);
+  world.setResource('position', positionStore);
+  world.setResource('collider', colliderStore);
+  world.setResource('player', playerStore);
+  world.setResource('health', healthStore);
+  world.setResource('collisionIntents', collisionIntents);
+
+  return {
+    colliderStore,
+    collisionIntents,
+    healthStore,
+    mapResource,
+    player,
+    playerStore,
+    positionStore,
+    system,
+    world,
+  };
+}
+
+/**
+ * Move one entity directly onto a chosen tile for collision tests.
+ *
+ * @param {PositionStore} positionStore - Mutable position store.
+ * @param {number} entityId - Entity slot to update.
+ * @param {number} row - Tile row to occupy.
+ * @param {number} col - Tile col to occupy.
+ */
+function setEntityTile(positionStore, entityId, row, col) {
+  positionStore.row[entityId] = row;
+  positionStore.col[entityId] = col;
+  positionStore.targetRow[entityId] = row;
+  positionStore.targetCol[entityId] = col;
+}
+
+describe('collision-system scaffold contract', () => {
+  it('registers as a logic-phase system so it can run after movement', () => {
+    const system = createCollisionSystem();
+
+    expect(system.phase).toBe('logic');
+  });
+
+  it('queries dynamic collision entities through position + collider masks', () => {
+    expect(COLLISION_ENTITY_REQUIRED_MASK).toBe(COMPONENT_MASK.POSITION | COMPONENT_MASK.COLLIDER);
+  });
+
+  it('uses the canonical default ghost lane count for one-cell occupancy buffers', () => {
+    expect(DEFAULT_GHOST_SLOTS_PER_CELL).toBe(4);
+  });
+});
+
+describe('collision-system helpers', () => {
+  it('converts in-bounds tile coordinates into flat cell indices', () => {
+    const mapResource = createMapResource(createCollisionRawMap());
+
+    expect(tileToCellIndex(mapResource, 0, 0)).toBe(0);
+    expect(tileToCellIndex(mapResource, 2, 3)).toBe(13);
+    expect(tileToCellIndex(mapResource, 4, 4)).toBe(24);
+  });
+
+  it('rejects out-of-bounds tile coordinates when computing flat cell indices', () => {
+    const mapResource = createMapResource(createCollisionRawMap());
+
+    expect(tileToCellIndex(mapResource, -1, 0)).toBe(-1);
+    expect(tileToCellIndex(mapResource, 0, -1)).toBe(-1);
+    expect(tileToCellIndex(mapResource, mapResource.rows, 0)).toBe(-1);
+    expect(tileToCellIndex(mapResource, 0, mapResource.cols)).toBe(-1);
+  });
+
+  it('copies one entity tile into a reusable output object', () => {
+    const positionStore = createPositionStore(2);
+    const outTile = { row: 0, col: 0 };
+
+    positionStore.row[1] = 2;
+    positionStore.col[1] = 3;
+
+    const returnedTile = readEntityTile(positionStore, 1, outTile);
+
+    expect(returnedTile).toBe(outTile);
+    expect(outTile).toEqual({ row: 2, col: 3 });
+  });
+
+  it('returns null when asked to read a tile from a missing position store', () => {
+    expect(readEntityTile(null, 0)).toBeNull();
+  });
+
+  it('allocates reusable scratch buffers sized from the map cell count', () => {
+    const scratch = createCollisionScratch(9);
+
+    expect(scratch.cellCount).toBe(9);
+    expect(scratch.maxGhostsPerCell).toBe(DEFAULT_GHOST_SLOTS_PER_CELL);
+    expect(scratch.playerByCell).toBeInstanceOf(Int32Array);
+    expect(scratch.bombByCell).toBeInstanceOf(Int32Array);
+    expect(scratch.fireByCell).toBeInstanceOf(Int32Array);
+    expect(scratch.ghostCounts).toBeInstanceOf(Uint8Array);
+    expect(scratch.ghostIds).toBeInstanceOf(Int32Array);
+    expect(scratch.ghostIds).toHaveLength(9 * DEFAULT_GHOST_SLOTS_PER_CELL);
+  });
+
+  it('resets every scratch occupancy lane back to deterministic sentinels', () => {
+    const scratch = createCollisionScratch(4, 2);
+
+    scratch.playerByCell[0] = 7;
+    scratch.bombByCell[1] = 8;
+    scratch.fireByCell[2] = 9;
+    scratch.ghostCounts[3] = 2;
+    scratch.ghostIds[4] = 10;
+
+    const returnedScratch = resetCollisionScratch(scratch);
+
+    expect(returnedScratch).toBe(scratch);
+    expect([...scratch.playerByCell]).toEqual([-1, -1, -1, -1]);
+    expect([...scratch.bombByCell]).toEqual([-1, -1, -1, -1]);
+    expect([...scratch.fireByCell]).toEqual([-1, -1, -1, -1]);
+    expect([...scratch.ghostCounts]).toEqual([0, 0, 0, 0]);
+    expect([...scratch.ghostIds]).toEqual([-1, -1, -1, -1, -1, -1, -1, -1]);
+  });
+
+  it('clears an injected collision intent array in place', () => {
+    const collisionIntents = [{ type: 'PelletCollected' }, { type: 'LifeLost' }];
+
+    const returnedBuffer = clearCollisionIntents(collisionIntents);
+
+    expect(returnedBuffer).toBe(collisionIntents);
+    expect(collisionIntents).toEqual([]);
+  });
+
+  it('appends deterministic collision intents with monotonic order values', () => {
+    const collisionIntents = [];
+
+    const firstIntent = appendCollisionIntent(collisionIntents, {
+      type: 'pellet-collected',
+      entityId: 1,
+    });
+    const secondIntent = appendCollisionIntent(collisionIntents, {
+      type: 'player-hit-fire',
+      entityId: 1,
+    });
+
+    expect(firstIntent).toEqual({
+      order: 0,
+      type: 'pellet-collected',
+      entityId: 1,
+    });
+    expect(secondIntent).toEqual({
+      order: 1,
+      type: 'player-hit-fire',
+      entityId: 1,
+    });
+    expect(collisionIntents).toEqual([firstIntent, secondIntent]);
+  });
+
+  it('collects a regular pellet by clearing the map tile and recording the pickup', () => {
+    const mapResource = createMapResource(createCollisionRawMap());
+    const collisionIntents = [];
+
+    const appendedIntent = collectStaticPickup(mapResource, collisionIntents, 4, 1, 1);
+
+    expect(appendedIntent).toEqual({
+      order: 0,
+      type: 'pellet-collected',
+      entityId: 4,
+      row: 1,
+      col: 1,
+    });
+    expect(getCell(mapResource, 1, 1)).toBe(CELL_TYPE.EMPTY);
+    expect(collisionIntents).toEqual([appendedIntent]);
+  });
+
+  it('collects a power pellet by clearing the map tile and recording the pickup', () => {
+    const mapResource = createMapResource(createCollisionRawMap([[1, 1, CELL_TYPE.POWER_PELLET]]));
+    const collisionIntents = [];
+
+    const appendedIntent = collectStaticPickup(mapResource, collisionIntents, 5, 1, 1);
+
+    expect(appendedIntent).toEqual({
+      order: 0,
+      type: 'power-pellet-collected',
+      entityId: 5,
+      row: 1,
+      col: 1,
+    });
+    expect(getCell(mapResource, 1, 1)).toBe(CELL_TYPE.EMPTY);
+    expect(collisionIntents).toEqual([appendedIntent]);
+  });
+
+  it('collects a bomb power-up tile and records the normalized power-up type', () => {
+    const mapResource = createMapResource(createCollisionRawMap([[1, 1, CELL_TYPE.POWER_UP_BOMB]]));
+    const collisionIntents = [];
+
+    const appendedIntent = collectStaticPickup(mapResource, collisionIntents, 6, 1, 1);
+
+    expect(appendedIntent).toEqual({
+      order: 0,
+      type: 'power-up-collected',
+      entityId: 6,
+      row: 1,
+      col: 1,
+      powerUpType: 'bombPlus',
+    });
+    expect(getCell(mapResource, 1, 1)).toBe(CELL_TYPE.EMPTY);
+  });
+
+  it('collects a fire power-up tile and records the normalized power-up type', () => {
+    const mapResource = createMapResource(createCollisionRawMap([[1, 1, CELL_TYPE.POWER_UP_FIRE]]));
+    const collisionIntents = [];
+
+    const appendedIntent = collectStaticPickup(mapResource, collisionIntents, 7, 1, 1);
+
+    expect(appendedIntent).toEqual({
+      order: 0,
+      type: 'power-up-collected',
+      entityId: 7,
+      row: 1,
+      col: 1,
+      powerUpType: 'firePlus',
+    });
+    expect(getCell(mapResource, 1, 1)).toBe(CELL_TYPE.EMPTY);
+  });
+
+  it('collects a speed power-up tile and records the normalized power-up type', () => {
+    const mapResource = createMapResource(
+      createCollisionRawMap([[1, 1, CELL_TYPE.POWER_UP_SPEED]]),
+    );
+    const collisionIntents = [];
+
+    const appendedIntent = collectStaticPickup(mapResource, collisionIntents, 8, 1, 1);
+
+    expect(appendedIntent).toEqual({
+      order: 0,
+      type: 'power-up-collected',
+      entityId: 8,
+      row: 1,
+      col: 1,
+      powerUpType: 'speedBoost',
+    });
+    expect(getCell(mapResource, 1, 1)).toBe(CELL_TYPE.EMPTY);
+  });
+
+  it('returns null without mutating the map when the tile is not collectible', () => {
+    const mapResource = createMapResource(createCollisionRawMap([[1, 1, CELL_TYPE.EMPTY]]));
+    const collisionIntents = [];
+
+    const appendedIntent = collectStaticPickup(mapResource, collisionIntents, 9, 1, 1);
+
+    expect(appendedIntent).toBeNull();
+    expect(getCell(mapResource, 1, 1)).toBe(CELL_TYPE.EMPTY);
+    expect(collisionIntents).toEqual([]);
+  });
+
+  it('treats the health flag as the highest-priority invincibility source', () => {
+    const playerStore = createPlayerStore(2);
+    const healthStore = createHealthStore(2);
+
+    playerStore.invincibilityMs[1] = 0;
+    healthStore.isInvincible[1] = 1;
+
+    expect(isPlayerInvincible(playerStore, healthStore, 1)).toBe(true);
+  });
+
+  it('falls back to the player invincibility timer when the health flag is absent', () => {
+    const playerStore = createPlayerStore(2);
+
+    playerStore.invincibilityMs[0] = 250;
+
+    expect(isPlayerInvincible(playerStore, null, 0)).toBe(true);
+    expect(isPlayerInvincible(playerStore, null, 1)).toBe(false);
+  });
+});
+
+describe('collision-system update shell', () => {
+  it('safely returns early without mutating external state when required resources are missing', () => {
+    const world = new World();
+    const system = createCollisionSystem();
+    const collisionIntents = [{ type: 'leave-me-alone' }];
+
+    world.setResource('collisionIntents', collisionIntents);
+
+    expect(() =>
+      system.update({
+        dtMs: 16.6667,
+        frame: 0,
+        world,
+      }),
+    ).not.toThrow();
+    expect(collisionIntents).toEqual([{ type: 'leave-me-alone' }]);
+  });
+
+  it('accepts a plain injected collision intent array and clears it for the new step', () => {
+    const { collisionIntents, system, world } = createCollisionHarness();
+
+    system.update({
+      dtMs: 16.6667,
+      frame: 0,
+      world,
+    });
+
+    expect(Array.isArray(collisionIntents)).toBe(true);
+    expect(collisionIntents).toEqual([]);
+  });
+
+  it('collects a pellet from the player tile during the system update', () => {
+    const { collisionIntents, mapResource, player, positionStore, system, world } =
+      createCollisionHarness();
+
+    setEntityTile(positionStore, player.id, 1, 1);
+
+    system.update({
+      dtMs: 16.6667,
+      frame: 0,
+      world,
+    });
+
+    expect(collisionIntents).toEqual([
+      {
+        order: 0,
+        type: 'pellet-collected',
+        entityId: player.id,
+        row: 1,
+        col: 1,
+      },
+    ]);
+    expect(getCell(mapResource, 1, 1)).toBe(CELL_TYPE.EMPTY);
+  });
+
+  it('does not emit a duplicate pickup when the cleared tile is checked on the next step', () => {
+    const { collisionIntents, mapResource, player, positionStore, system, world } =
+      createCollisionHarness();
+
+    setEntityTile(positionStore, player.id, 1, 1);
+
+    system.update({
+      dtMs: 16.6667,
+      frame: 0,
+      world,
+    });
+    expect(collisionIntents).toHaveLength(1);
+
+    system.update({
+      dtMs: 16.6667,
+      frame: 1,
+      world,
+    });
+
+    expect(collisionIntents).toEqual([]);
+    expect(getCell(mapResource, 1, 1)).toBe(CELL_TYPE.EMPTY);
+  });
+
+  it('ignores collectible tiles for non-player colliders', () => {
+    const { colliderStore, collisionIntents, mapResource, positionStore, system, world } =
+      createCollisionHarness();
+    const ghost = world.createEntity(COLLISION_ENTITY_REQUIRED_MASK);
+
+    colliderStore.type[ghost.id] = COLLIDER_TYPE.GHOST;
+    setEntityTile(positionStore, ghost.id, 1, 1);
+
+    system.update({
+      dtMs: 16.6667,
+      frame: 0,
+      world,
+    });
+
+    expect(collisionIntents).toEqual([]);
+    expect(getCell(mapResource, 1, 1)).toBe(CELL_TYPE.PELLET);
+  });
+
+  it('uses a real map resource fixture so the harness stays aligned with D-03 semantics', () => {
+    const { mapResource } = createCollisionHarness();
+
+    expect(mapResource.playerSpawnRow).toBe(2);
+    expect(mapResource.playerSpawnCol).toBe(2);
+    expect(mapResource.grid2D[3][2]).toBe(CELL_TYPE.GHOST_HOUSE);
+  });
+});

--- a/tests/unit/systems/collision-system.test.js
+++ b/tests/unit/systems/collision-system.test.js
@@ -9,7 +9,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { createPlayerStore } from '../../../src/ecs/components/actors.js';
+import { createGhostStore, createPlayerStore } from '../../../src/ecs/components/actors.js';
 import { COMPONENT_MASK } from '../../../src/ecs/components/registry.js';
 import {
   COLLIDER_TYPE,
@@ -17,7 +17,7 @@ import {
   createPositionStore,
 } from '../../../src/ecs/components/spatial.js';
 import { createHealthStore } from '../../../src/ecs/components/stats.js';
-import { CELL_TYPE } from '../../../src/ecs/resources/constants.js';
+import { CELL_TYPE, GHOST_STATE } from '../../../src/ecs/resources/constants.js';
 import { createMapResource, getCell } from '../../../src/ecs/resources/map-resource.js';
 import {
   appendCollisionIntent,
@@ -86,6 +86,7 @@ function createCollisionRawMap(overrides = []) {
  * @returns {{
  *   colliderStore: ColliderStore,
  *   collisionIntents: Array<object>,
+ *   ghostStore: GhostStore,
  *   healthStore: HealthStore,
  *   mapResource: MapResource,
  *   player: { id: number, generation: number },
@@ -102,6 +103,7 @@ function createCollisionHarness(mapOverrides = []) {
   const positionStore = createPositionStore(8);
   const colliderStore = createColliderStore(8);
   const playerStore = createPlayerStore(8);
+  const ghostStore = createGhostStore(8);
   const healthStore = createHealthStore(8);
   const collisionIntents = [{ type: 'stale-intent' }];
   const player = world.createEntity(COLLISION_ENTITY_REQUIRED_MASK);
@@ -117,12 +119,14 @@ function createCollisionHarness(mapOverrides = []) {
   world.setResource('position', positionStore);
   world.setResource('collider', colliderStore);
   world.setResource('player', playerStore);
+  world.setResource('ghost', ghostStore);
   world.setResource('health', healthStore);
   world.setResource('collisionIntents', collisionIntents);
 
   return {
     colliderStore,
     collisionIntents,
+    ghostStore,
     healthStore,
     mapResource,
     player,
@@ -146,6 +150,26 @@ function setEntityTile(positionStore, entityId, row, col) {
   positionStore.col[entityId] = col;
   positionStore.targetRow[entityId] = row;
   positionStore.targetCol[entityId] = col;
+}
+
+/**
+ * Create one extra collision entity and place it on a chosen tile.
+ *
+ * @param {World} world - ECS world receiving the entity.
+ * @param {PositionStore} positionStore - Mutable position store.
+ * @param {ColliderStore} colliderStore - Mutable collider store.
+ * @param {number} colliderType - Canonical collider type to assign.
+ * @param {number} row - Tile row to occupy.
+ * @param {number} col - Tile col to occupy.
+ * @returns {{ id: number, generation: number }} Created entity handle.
+ */
+function addCollisionEntity(world, positionStore, colliderStore, colliderType, row, col) {
+  const entity = world.createEntity(COLLISION_ENTITY_REQUIRED_MASK);
+
+  colliderStore.type[entity.id] = colliderType;
+  setEntityTile(positionStore, entity.id, row, col);
+
+  return entity;
 }
 
 describe('collision-system scaffold contract', () => {
@@ -477,6 +501,321 @@ describe('collision-system update shell', () => {
 
     expect(collisionIntents).toEqual([]);
     expect(getCell(mapResource, 1, 1)).toBe(CELL_TYPE.PELLET);
+  });
+
+  it('records a player-death intent when fire occupies the player tile', () => {
+    const { colliderStore, collisionIntents, player, positionStore, system, world } =
+      createCollisionHarness();
+
+    setEntityTile(positionStore, player.id, 1, 1);
+    addCollisionEntity(world, positionStore, colliderStore, COLLIDER_TYPE.FIRE, 1, 1);
+
+    system.update({
+      dtMs: 16.6667,
+      frame: 0,
+      world,
+    });
+
+    expect(collisionIntents).toEqual([
+      {
+        order: 0,
+        type: 'pellet-collected',
+        entityId: player.id,
+        row: 1,
+        col: 1,
+      },
+      {
+        order: 1,
+        type: 'player-death',
+        entityId: player.id,
+        row: 1,
+        col: 1,
+        cause: 'fire',
+        sourceEntityId: 1,
+      },
+    ]);
+  });
+
+  it('suppresses fire damage when the player is invincible through the player timer', () => {
+    const { colliderStore, collisionIntents, player, playerStore, positionStore, system, world } =
+      createCollisionHarness();
+
+    playerStore.invincibilityMs[player.id] = 1500;
+    setEntityTile(positionStore, player.id, 1, 2);
+    addCollisionEntity(world, positionStore, colliderStore, COLLIDER_TYPE.FIRE, 1, 2);
+
+    system.update({
+      dtMs: 16.6667,
+      frame: 0,
+      world,
+    });
+
+    expect(collisionIntents).toEqual([
+      {
+        order: 0,
+        type: 'pellet-collected',
+        entityId: player.id,
+        row: 1,
+        col: 2,
+      },
+    ]);
+  });
+
+  it('suppresses fire damage when the player is invincible through the health flag', () => {
+    const { colliderStore, collisionIntents, healthStore, player, positionStore, system, world } =
+      createCollisionHarness();
+
+    healthStore.isInvincible[player.id] = 1;
+    setEntityTile(positionStore, player.id, 1, 3);
+    addCollisionEntity(world, positionStore, colliderStore, COLLIDER_TYPE.FIRE, 1, 3);
+
+    system.update({
+      dtMs: 16.6667,
+      frame: 0,
+      world,
+    });
+
+    expect(collisionIntents).toEqual([
+      {
+        order: 0,
+        type: 'pellet-collected',
+        entityId: player.id,
+        row: 1,
+        col: 3,
+      },
+    ]);
+  });
+
+  it('records a ghost-death intent when fire occupies a normal ghost tile', () => {
+    const { colliderStore, collisionIntents, ghostStore, positionStore, system, world } =
+      createCollisionHarness([[1, 1, CELL_TYPE.EMPTY]]);
+
+    const ghost = addCollisionEntity(
+      world,
+      positionStore,
+      colliderStore,
+      COLLIDER_TYPE.GHOST,
+      1,
+      1,
+    );
+    addCollisionEntity(world, positionStore, colliderStore, COLLIDER_TYPE.FIRE, 1, 1);
+
+    system.update({
+      dtMs: 16.6667,
+      frame: 0,
+      world,
+    });
+
+    expect(collisionIntents).toEqual([
+      {
+        order: 0,
+        type: 'ghost-death',
+        entityId: ghost.id,
+        row: 1,
+        col: 1,
+        cause: 'fire',
+        sourceEntityId: 2,
+        ghostState: GHOST_STATE.NORMAL,
+      },
+    ]);
+    expect(ghostStore.state[ghost.id]).toBe(GHOST_STATE.DEAD);
+  });
+
+  it('records a ghost-death intent for a stunned ghost and preserves the prior state in the intent', () => {
+    const { colliderStore, collisionIntents, ghostStore, positionStore, system, world } =
+      createCollisionHarness([[1, 2, CELL_TYPE.EMPTY]]);
+
+    const ghost = addCollisionEntity(
+      world,
+      positionStore,
+      colliderStore,
+      COLLIDER_TYPE.GHOST,
+      1,
+      2,
+    );
+    ghostStore.state[ghost.id] = GHOST_STATE.STUNNED;
+    addCollisionEntity(world, positionStore, colliderStore, COLLIDER_TYPE.FIRE, 1, 2);
+
+    system.update({
+      dtMs: 16.6667,
+      frame: 0,
+      world,
+    });
+
+    expect(collisionIntents).toEqual([
+      {
+        order: 0,
+        type: 'ghost-death',
+        entityId: ghost.id,
+        row: 1,
+        col: 2,
+        cause: 'fire',
+        sourceEntityId: 2,
+        ghostState: GHOST_STATE.STUNNED,
+      },
+    ]);
+    expect(ghostStore.state[ghost.id]).toBe(GHOST_STATE.DEAD);
+  });
+
+  it('ignores dead ghosts when fire occupies the same tile', () => {
+    const { colliderStore, collisionIntents, ghostStore, positionStore, system, world } =
+      createCollisionHarness([[1, 3, CELL_TYPE.EMPTY]]);
+
+    const ghost = addCollisionEntity(
+      world,
+      positionStore,
+      colliderStore,
+      COLLIDER_TYPE.GHOST,
+      1,
+      3,
+    );
+    ghostStore.state[ghost.id] = GHOST_STATE.DEAD;
+    addCollisionEntity(world, positionStore, colliderStore, COLLIDER_TYPE.FIRE, 1, 3);
+
+    system.update({
+      dtMs: 16.6667,
+      frame: 0,
+      world,
+    });
+
+    expect(collisionIntents).toEqual([]);
+    expect(ghostStore.state[ghost.id]).toBe(GHOST_STATE.DEAD);
+  });
+
+  it('records a player-death intent for contact with a normal ghost when no fire is present', () => {
+    const { colliderStore, collisionIntents, player, positionStore, system, world } =
+      createCollisionHarness();
+
+    setEntityTile(positionStore, player.id, 1, 2);
+    addCollisionEntity(world, positionStore, colliderStore, COLLIDER_TYPE.GHOST, 1, 2);
+
+    system.update({
+      dtMs: 16.6667,
+      frame: 0,
+      world,
+    });
+
+    expect(collisionIntents).toEqual([
+      {
+        order: 0,
+        type: 'pellet-collected',
+        entityId: player.id,
+        row: 1,
+        col: 2,
+      },
+      {
+        order: 1,
+        type: 'player-death',
+        entityId: player.id,
+        row: 1,
+        col: 2,
+        cause: 'ghost',
+        sourceEntityId: 1,
+        ghostState: GHOST_STATE.NORMAL,
+      },
+    ]);
+  });
+
+  it('does not record player death for contact with a stunned ghost', () => {
+    const { colliderStore, collisionIntents, ghostStore, player, positionStore, system, world } =
+      createCollisionHarness();
+
+    setEntityTile(positionStore, player.id, 1, 3);
+    const ghost = addCollisionEntity(
+      world,
+      positionStore,
+      colliderStore,
+      COLLIDER_TYPE.GHOST,
+      1,
+      3,
+    );
+    ghostStore.state[ghost.id] = GHOST_STATE.STUNNED;
+
+    system.update({
+      dtMs: 16.6667,
+      frame: 0,
+      world,
+    });
+
+    expect(collisionIntents).toEqual([
+      {
+        order: 0,
+        type: 'pellet-collected',
+        entityId: player.id,
+        row: 1,
+        col: 3,
+      },
+    ]);
+  });
+
+  it('suppresses ghost-contact death when the player is invincible', () => {
+    const { colliderStore, collisionIntents, healthStore, player, positionStore, system, world } =
+      createCollisionHarness();
+
+    healthStore.isInvincible[player.id] = 1;
+    setEntityTile(positionStore, player.id, 1, 2);
+    addCollisionEntity(world, positionStore, colliderStore, COLLIDER_TYPE.GHOST, 1, 2);
+
+    system.update({
+      dtMs: 16.6667,
+      frame: 0,
+      world,
+    });
+
+    expect(collisionIntents).toEqual([
+      {
+        order: 0,
+        type: 'pellet-collected',
+        entityId: player.id,
+        row: 1,
+        col: 2,
+      },
+    ]);
+  });
+
+  it('prioritizes fire over ghost contact when both occupy the player tile', () => {
+    const { colliderStore, collisionIntents, ghostStore, player, positionStore, system, world } =
+      createCollisionHarness([[1, 1, CELL_TYPE.EMPTY]]);
+
+    setEntityTile(positionStore, player.id, 1, 1);
+    const ghost = addCollisionEntity(
+      world,
+      positionStore,
+      colliderStore,
+      COLLIDER_TYPE.GHOST,
+      1,
+      1,
+    );
+    addCollisionEntity(world, positionStore, colliderStore, COLLIDER_TYPE.FIRE, 1, 1);
+
+    system.update({
+      dtMs: 16.6667,
+      frame: 0,
+      world,
+    });
+
+    expect(collisionIntents).toEqual([
+      {
+        order: 0,
+        type: 'player-death',
+        entityId: player.id,
+        row: 1,
+        col: 1,
+        cause: 'fire',
+        sourceEntityId: 2,
+      },
+      {
+        order: 1,
+        type: 'ghost-death',
+        entityId: ghost.id,
+        row: 1,
+        col: 1,
+        cause: 'fire',
+        sourceEntityId: 2,
+        ghostState: GHOST_STATE.NORMAL,
+      },
+    ]);
+    expect(ghostStore.state[ghost.id]).toBe(GHOST_STATE.DEAD);
   });
 
   it('uses a real map resource fixture so the harness stays aligned with D-03 semantics', () => {

--- a/tests/unit/systems/collision-system.test.js
+++ b/tests/unit/systems/collision-system.test.js
@@ -1,10 +1,9 @@
 /**
- * Unit tests for the B-04 collision-system scaffold.
+ * Unit tests for the B-04 collision system.
  *
- * These tests prove the helper and system-shell contract: logic-phase
- * registration, deterministic helper behavior, reusable scratch buffers, and
- * the ability to inject a plain collision intent array without requiring a
- * dedicated resource module yet.
+ * These tests cover the helper layer, the logic-phase system contract, pickup
+ * collection, fire and ghost contact, and occupancy-rule enforcement without
+ * depending on runtime wiring in out-of-scope files.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -191,7 +190,7 @@ function addCollisionEntity(world, positionStore, colliderStore, colliderType, r
   return entity;
 }
 
-describe('collision-system scaffold contract', () => {
+describe('collision-system contract', () => {
   it('registers as a logic-phase system so it can run after movement', () => {
     const system = createCollisionSystem();
 
@@ -204,6 +203,17 @@ describe('collision-system scaffold contract', () => {
 
   it('uses the canonical default ghost lane count for one-cell occupancy buffers', () => {
     expect(DEFAULT_GHOST_SLOTS_PER_CELL).toBe(4);
+  });
+
+  it('declares writes for every resource the system mutates during collision resolution', () => {
+    const system = createCollisionSystem();
+
+    expect(system.resourceCapabilities.write).toEqual([
+      'mapResource',
+      'position',
+      'ghost',
+      'collisionIntents',
+    ]);
   });
 });
 


### PR DESCRIPTION
# PR Gate Checklist

Local test command reference (run what applies to your change and list what you ran in the `## Tests` section below):

- Baseline for every change: `npm run check`, `npm run fix`, `npm run test`, `npm run policy`
- Unit-only slices: `npm run test:unit`
- Cross-system or adapter changes: `npm run test:integration`
- Browser/runtime behavior changes (pause, input, HUD, rendering, gameplay): `npm run test:e2e`
- Audit-map updates: `npm run test:audit`
- Manifest/schema updates: `npm run validate:schema`
- Local checks rerun with prepared metadata: `npm run policy:checks:local`
- Repo-only troubleshooting rerun: `npm run policy:repo`

## Required checks

- [x] I read AGENTS.md and the agentic workflow guide.
- [x] I ran `npm run policy` locally.
 - [x] I verified my branch name follows `<owner-or-scope>/<TRACK>-<NN>[-<COMMENT>]` (for example `ekaramet/A-03` or `asmyrogl/B-03-runtime-integration`), or I marked the PR body with `process` for a GENERAL_DOCS_PROCESS branch.
- [x] I confirmed changed files stay within the declared ticket ownership scope.
- [x] I ran the applicable local checks for this change.
- [x] I listed each affected AUDIT ID with execution type (Fully Automatable, Semi-Automatable, or Manual-With-Evidence) and linked the passing test output or evidence artifact.
- [x] I confirmed full audit coverage remains mapped for F-01 through F-21 and B-01 through B-06.
- [x] If affected, I attached Manual-With-Evidence artifacts for F-19, F-20, F-21, and B-06.
- [x] I checked security sinks and trust boundaries.
- [x] I checked architecture boundaries.
- [x] I checked dependency and lockfile impact.
- [x] I requested human review.

## Layer boundary confirmation

- [x] `src/ecs/systems/` has no DOM references except `render-dom-system.js`
- [x] Simulation systems access adapters only through World resources (no direct adapter imports)
- [x] `src/adapters/` owns DOM and browser I/O side effects
- [x] Untrusted UI content uses safe sinks (`textContent` / explicit attributes), not HTML injection
- [x] No framework imports or canvas APIs were introduced in this change

## What changed
- Implemented `src/ecs/systems/collision-system.js` for B-04 using a deterministic cell-occupancy approach for player, ghost, bomb, and fire collisions.
- Added static pickup collection for pellets, power pellets, and map power-ups, clearing collected cells immediately and recording collision intents instead of mutating score/lives directly.
- Implemented the collision priority required by the ticket: invincibility over fire, and fire over ghost contact.
- Implemented fire vs player, fire vs ghost, normal ghost contact vs player, and harmless stunned-ghost contact handling.
- Enforced ghost-house occupancy rules: player blocked from `G`, ghosts allowed to exit, and only dead ghosts allowed to re-enter.
- Enforced bomb-cell rules, including path-around blocking and shared-cell bomb push-back when a bomb is dropped on a ghost's current tile.
- Added focused unit coverage in `tests/unit/systems/collision-system.test.js`.
- Added gameplay integration coverage in `tests/integration/gameplay/b-04-collision-system.test.js` to validate ECS phase ordering and mixed collision scenarios through `World.runFixedStep()`.

## Why
- B-04 owns the gameplay-correct overlap rules between player, ghosts, bombs, fire, pellets, and power-ups.
- The collision system needs deterministic ordering so later scoring, lives, audio, and event-surface tickets can consume stable intent output.
- Ghost-house and bomb-cell rules are part of the gameplay contract, not optional polish, so they need to live in simulation rather than being left to later runtime wiring.
- The integration tests lock the `physics -> logic` collision path so future movement or system-registration changes do not silently break gameplay behavior.

## Tests
- User-reported: all applicable tests were run locally and passed.
- Focused collision verification also passed for:
  - `npx vitest run tests/unit/systems/collision-system.test.js tests/integration/gameplay/b-04-collision-system.test.js`
  - `npm run test:unit`
  - `npm run test:integration`
  - `npx biome check src/ecs/systems/collision-system.js tests/unit/systems/collision-system.test.js tests/integration/gameplay/b-04-collision-system.test.js`

## Audit questions affected
- `AUDIT-F-13 | Execution type: Fully Automatable | Verification: collision permutations and gameplay interaction coverage in tests/unit/systems/collision-system.test.js and tests/integration/gameplay/b-04-collision-system.test.js | Evidence path/link: tests/unit/systems/collision-system.test.js, tests/integration/gameplay/b-04-collision-system.test.js`

## Security notes
- No unsafe DOM sinks, inline event handlers, framework imports, canvas APIs, or dynamic code execution were introduced.
- The change stays inside ECS simulation and test code, so it does not expand the browser trust boundary.
- Collision results are recorded as intents in plain data structures rather than dispatched through DOM or adapter side effects.

## Architecture / dependency notes
- `src/ecs/systems/collision-system.js` remains a simulation system with no DOM access and no direct adapter imports.
- The system reads and writes only World resources and ECS component stores.
- Score/life authority is intentionally left to later consumers of collision intents, which keeps B-04 within its ownership boundary.
- Runtime registration of the collision system and downstream intent consumers are still owned by other tickets/tracks.
- `docs/implementation/ticket-tracker.md` still lists `A-11` as a blocker for `B-04`; if your team has explicitly approved proceeding anyway, reviewers should note that exception in PR discussion.

## Risks
- Runtime wiring is still pending outside this ticket, so this PR completes the collision system itself but not full in-game registration.
- `ghostStore.state` is updated to `DEAD` immediately on fire kill to prevent repeated death intents; if B-08 later centralizes ghost state transitions, that contract may need to be revisited.
- Ghost-house entry is currently enforced as "dead ghosts only" based on the existing map geometry; if future maps expose additional ghost-house perimeter shapes, the rule may need to become a more explicit gate model.
