### PR TITLE
Track A: Fix event queue bugs (BUG-16, BUG-01, DEAD-01)

### DIFF
--- a/docs/pr-messages/pr-bugfix-A-129-137-114-eventqueue-cleanup.md
+++ b/docs/pr-messages/pr-bugfix-A-129-137-114-eventqueue-cleanup.md
@@ -1,0 +1,63 @@
+# 🚀 Track A: Fix event queue bugs (BUG-16, BUG-01, DEAD-01)
+
+> **Summary**: Clear event queue on restart to prevent phantom SFX replay, drain queue each frame to prevent unbounded memory growth, and verify `changed-files.txt` is already gitignored and untracked.
+
+---
+
+## 📝 Description
+
+### 🔄 What Changed
+- **`src/game/bootstrap.js`**: Reset `eventQueue` resource in `onRestart` callback so stale events (e.g., `BombDetonated`, `GhostDefeated`, `LevelCleared`) are not replayed on the first post-restart tick.
+- **`src/main.ecs.js`**: Call `drain()` on the event queue after `stepFrame()` in the game runtime loop to prevent unbounded event accumulation (~216K events/hour at 60 Hz).
+- **`tests/unit/game/bootstrap-extended.test.js`**: Added test verifying event queue is empty after restart (BUG-16).
+- **`tests/unit/main.ecs.test.js`**: Added test verifying event queue is drained each frame through the game runtime (BUG-01).
+
+### 🎯 Why
+- **BUG-16 (HIGH)**: Phantom sounds play on restart because previously enqueued events are replayed by the audio cue runner. The fix clears the event queue during restart, ensuring a clean slate.
+- **BUG-01 (MEDIUM)**: Five simulation systems emit events each fixed step but no consumer calls `drain()`, causing a memory leak. The fix drains the queue in the rAF loop after each frame's simulation completes.
+- **DEAD-01 (MEDIUM)**: `changed-files.txt` was already added to `.gitignore` and is no longer tracked; verified to confirm the issue is resolved.
+
+---
+
+## 🧪 Verification & Audit
+
+### ✅ Verification
+- **`npm run check`**: Biome lint passes with 0 errors.
+- **`npm run test`**: 1047 tests pass (81 test files).
+- **`npm run policy:checks`**: Policy checks pass (bugfix mode).
+- **`npm run policy:forbidden`**: No forbidden patterns found.
+- **`npm run policy:header`**: Source headers compliant.
+
+### 📋 Audit Traceability
+- N/A — Bug fixes and cleanup, no direct AUDIT mapping.
+
+---
+
+## ✅ PR Gate Checklist
+
+### 📋 Required Checks
+- [x] **Read Standards**: Reviewed AGENTS.md and agentic workflow guide.
+- [x] **Policy Compliance**: Ran policy checks locally; all pass.
+- [x] **Ownership**: Files remain within Track A ownership scope (bootstrap.js, main.ecs.js, test files).
+- [x] **Branching**: Branch name follows `ekaramet/bugfix-A-<NN>-<short-description>` convention.
+- [x] **Audit Coverage**: No new AUDIT requirements introduced.
+- [x] **Evidence**: Not applicable (no Manual-With-Evidence items).
+
+### 🏗️ Architecture & Security
+- [x] **ECS Isolation**: No DOM references in systems. Event queue accessed through world resource API.
+- [x] **Adapter Injection**: No direct adapter imports. `drain()` is called in the runtime orchestrator (`main.ecs.js`), not in simulation systems.
+- [x] **Safe Sinks**: Only `textContent` and safe attribute APIs used.
+- [x] **No Bloat**: No framework imports or canvas APIs.
+- [x] **Dependencies**: No dependency changes.
+
+---
+
+## 🛡️ Security & Architecture Notes
+- **Architecture**: Event queue drain is correctly placed in the rAF loop (not in `bootstrap.stepFrame()`) so integration tests that inspect drained events can still call `stepFrame` directly.
+- **Risks**: Low — the changes are narrow and well-scoped. Existing integration tests continue to pass.
+
+---
+
+Closes #129
+Closes #114
+Closes #137

--- a/src/game/bootstrap.js
+++ b/src/game/bootstrap.js
@@ -754,6 +754,9 @@ export function createBootstrap(options = {}) {
     options.playerEntityResourceKey || DEFAULT_PLAYER_ENTITY_RESOURCE_KEY;
   const clock = createClock(nowMs);
   const gameStatus = createGameStatus();
+  // BUG-16: Resolve the event queue resource key early so it can be accessed
+  // by gameFlow's onRestart closure during synchronous browser startup.
+  const eventQueueResourceKey = options.eventQueueResourceKey || DEFAULT_EVENT_QUEUE_RESOURCE_KEY;
 
   // Resolve a single now-source for restart resyncs. Tests wire a synthetic
   // `nowProvider` so the restart path stays deterministic; production falls
@@ -874,7 +877,6 @@ export function createBootstrap(options = {}) {
   // B-05: Register the canonical event queue resource so Track B simulation
   // systems can emit deterministic cross-system events without importing
   // bootstrap or adapter modules. Systems access this only via world.getResource.
-  const eventQueueResourceKey = options.eventQueueResourceKey || DEFAULT_EVENT_QUEUE_RESOURCE_KEY;
   ensureWorldResource(world, eventQueueResourceKey, createEventQueue);
   world.setResource('gameFlow', gameFlow);
   world.setResource('gameStatus', gameStatus);

--- a/src/game/bootstrap.js
+++ b/src/game/bootstrap.js
@@ -848,6 +848,11 @@ export function createBootstrap(options = {}) {
       world.setResource('levelFlow', {});
       world.setResource('bombCellOccupancy', new Set());
 
+      // BUG-16: Reset the event queue so stale events from the previous run
+      // (e.g., BombDetonated, GhostDefeated, LevelCleared) are not replayed
+      // by the audio cue runner on the first post-restart tick.
+      world.setResource(eventQueueResourceKey, createEventQueue());
+
       // D-09: Reset sprite pool so old sprites are returned to idle state.
       // This combined with render-dom-system's frame-0 map clear ensures
       // that sprites are correctly re-acquired for new entities.

--- a/src/main.ecs.js
+++ b/src/main.ecs.js
@@ -42,6 +42,7 @@ import { createInputAdapter } from './adapters/io/input-adapter.js';
 import { getHighScore, saveHighScore } from './adapters/io/storage-adapter.js';
 import { percentileFromSorted, toSortedNumericArray } from './debug/frame-stats.js';
 import { FIXED_DT_MS, MAX_STEPS_PER_FRAME, TOTAL_LEVELS } from './ecs/resources/constants.js';
+import { drain } from './ecs/resources/event-queue.js';
 import { createMapResource } from './ecs/resources/map-resource.js';
 import { createBootstrap } from './game/bootstrap.js';
 import { createSyncMapLoader } from './game/level-loader.js';
@@ -345,6 +346,16 @@ export function createGameRuntime({
         fixedDtMs: FIXED_DT_MS,
         maxStepsPerFrame: MAX_STEPS_PER_FRAME,
       });
+
+      // BUG-01: Drain the event queue each frame so events emitted by
+      // simulation systems do not accumulate unboundedly. The queue is
+      // consumed here in the rAF loop (not in bootstrap.stepFrame) so
+      // integration tests that inspect drained events can still call
+      // stepFrame directly without the automatic clearing.
+      const eventQueue = bootstrap.world.getResource(bootstrap.eventQueueResourceKey);
+      if (eventQueue) {
+        drain(eventQueue);
+      }
     } catch (error) {
       // Catch unexpected errors outside the system-dispatch boundary
       // (e.g., tickClock, applyDeferredMutations) so the loop survives.

--- a/src/main.ecs.js
+++ b/src/main.ecs.js
@@ -352,9 +352,11 @@ export function createGameRuntime({
       // consumed here in the rAF loop (not in bootstrap.stepFrame) so
       // integration tests that inspect drained events can still call
       // stepFrame directly without the automatic clearing.
-      const eventQueue = bootstrap.world.getResource(bootstrap.eventQueueResourceKey);
-      if (eventQueue) {
-        drain(eventQueue);
+      if (bootstrap.world && bootstrap.eventQueueResourceKey) {
+        const eventQueue = bootstrap.world.getResource(bootstrap.eventQueueResourceKey);
+        if (eventQueue) {
+          drain(eventQueue);
+        }
       }
     } catch (error) {
       // Catch unexpected errors outside the system-dispatch boundary

--- a/tests/unit/game/bootstrap-extended.test.js
+++ b/tests/unit/game/bootstrap-extended.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { FIXED_DT_MS } from '../../../src/ecs/resources/constants.js';
+import { enqueue } from '../../../src/ecs/resources/event-queue.js';
 import { GAME_STATE } from '../../../src/ecs/resources/game-status.js';
 import { createBootstrap } from '../../../src/game/bootstrap.js';
 
@@ -198,5 +199,30 @@ describe('Bootstrap extended coverage', () => {
     bootstrap.world.setResource('spritePool', invalidSpritePool);
     bootstrap.gameFlow.setState(GAME_STATE.PLAYING);
     expect(() => bootstrap.gameFlow.restartLevel()).not.toThrow();
+  });
+
+  it('clears eventQueue on restart (BUG-16)', () => {
+    const bootstrap = createBootstrap({ now: 0 });
+    const world = bootstrap.world;
+    const eventQueue = world.getResource(bootstrap.eventQueueResourceKey);
+
+    enqueue(eventQueue, 'TestEvent', { value: 42 }, 0);
+    enqueue(eventQueue, 'AnotherEvent', { value: 99 }, 0);
+
+    expect(eventQueue.events.length).toBe(2);
+
+    bootstrap.gameFlow.setState(GAME_STATE.PLAYING);
+    bootstrap.gameFlow.restartLevel();
+
+    const freshQueue = world.getResource(bootstrap.eventQueueResourceKey);
+    expect(freshQueue.events.length).toBe(0);
+  });
+
+  it('exports eventQueueResourceKey for runtime drain (BUG-01)', () => {
+    const bootstrap = createBootstrap({ now: 0 });
+
+    expect(typeof bootstrap.eventQueueResourceKey).toBe('string');
+    expect(bootstrap.eventQueueResourceKey.length).toBeGreaterThan(0);
+    expect(bootstrap.world.hasResource(bootstrap.eventQueueResourceKey)).toBe(true);
   });
 });

--- a/tests/unit/main.ecs.test.js
+++ b/tests/unit/main.ecs.test.js
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { enqueue } from '../../src/ecs/resources/event-queue.js';
+import { GAME_STATE } from '../../src/ecs/resources/game-status.js';
+import { createBootstrap } from '../../src/game/bootstrap.js';
 import {
   bootstrapApplication,
   createGameRuntime,
@@ -268,6 +271,35 @@ describe('main.ecs.js', () => {
       expect(stats.p95FrameTime).toBeCloseTo(16, 5);
       expect(stats.p99FrameTime).toBeCloseTo(16, 5);
       expect(stats.p95Fps).toBeCloseTo(62.5, 1);
+
+      runtime.stop();
+    });
+
+    it('drains event queue each frame through game runtime (BUG-01)', () => {
+      const scheduledFrames = [];
+      const requestFrame = vi.fn((cb) => {
+        scheduledFrames.push(cb);
+        return scheduledFrames.length;
+      });
+
+      const bootstrap = createBootstrap({ now: 0 });
+      const eventQueue = bootstrap.world.getResource(bootstrap.eventQueueResourceKey);
+
+      bootstrap.gameFlow.setState(GAME_STATE.PLAYING);
+      enqueue(eventQueue, 'TestEvent', { value: 1 }, 0);
+
+      const runtime = createGameRuntime({
+        bootstrap,
+        nowProvider: () => 0,
+        requestFrame,
+        cancelFrame: vi.fn(),
+      });
+
+      runtime.start();
+
+      scheduledFrames.shift()(16);
+
+      expect(eventQueue.events.length).toBe(0);
 
       runtime.stop();
     });


### PR DESCRIPTION
# 🚀 Track A: Fix event queue bugs (BUG-16, BUG-01, DEAD-01)

> **Summary**: Clear event queue on restart to prevent phantom SFX replay, drain queue each frame to prevent unbounded memory growth, and verify `changed-files.txt` is already gitignored and untracked.

---

## 📝 Description

### 🔄 What Changed
- **`src/game/bootstrap.js`**: Reset `eventQueue` resource in `onRestart` callback so stale events (e.g., `BombDetonated`, `GhostDefeated`, `LevelCleared`) are not replayed on the first post-restart tick.
- **`src/main.ecs.js`**: Call `drain()` on the event queue after `stepFrame()` in the game runtime loop to prevent unbounded event accumulation (~216K events/hour at 60 Hz).
- **`tests/unit/game/bootstrap-extended.test.js`**: Added test verifying event queue is empty after restart (BUG-16).
- **`tests/unit/main.ecs.test.js`**: Added test verifying event queue is drained each frame through the game runtime (BUG-01).

### 🎯 Why
- **BUG-16 (HIGH)**: Phantom sounds play on restart because previously enqueued events are replayed by the audio cue runner. The fix clears the event queue during restart, ensuring a clean slate.
- **BUG-01 (MEDIUM)**: Five simulation systems emit events each fixed step but no consumer calls `drain()`, causing a memory leak. The fix drains the queue in the rAF loop after each frame's simulation completes.
- **DEAD-01 (MEDIUM)**: `changed-files.txt` was already added to `.gitignore` and is no longer tracked; verified to confirm the issue is resolved.

---

## 🧪 Verification & Audit

### ✅ Verification
- **`npm run check`**: Biome lint passes with 0 errors.
- **`npm run test`**: 1047 tests pass (81 test files).
- **`npm run policy:checks`**: Policy checks pass (bugfix mode).
- **`npm run policy:forbidden`**: No forbidden patterns found.
- **`npm run policy:header`**: Source headers compliant.

### 📋 Audit Traceability
- N/A — Bug fixes and cleanup, no direct AUDIT mapping.

---

## ✅ PR Gate Checklist

### 📋 Required Checks
- [x] **Read Standards**: Reviewed AGENTS.md and agentic workflow guide.
- [x] **Policy Compliance**: Ran policy checks locally; all pass.
- [x] **Ownership**: Files remain within Track A ownership scope (bootstrap.js, main.ecs.js, test files).
- [x] **Branching**: Branch name follows `ekaramet/bugfix-A-<NN>-<short-description>` convention.
- [x] **Audit Coverage**: No new AUDIT requirements introduced.
- [x] **Evidence**: Not applicable (no Manual-With-Evidence items).

### 🏗️ Architecture & Security
- [x] **ECS Isolation**: No DOM references in systems. Event queue accessed through world resource API.
- [x] **Adapter Injection**: No direct adapter imports. `drain()` is called in the runtime orchestrator (`main.ecs.js`), not in simulation systems.
- [x] **Safe Sinks**: Only `textContent` and safe attribute APIs used.
- [x] **No Bloat**: No framework imports or canvas APIs.
- [x] **Dependencies**: No dependency changes.

---

## 🛡️ Security & Architecture Notes
- **Architecture**: Event queue drain is correctly placed in the rAF loop (not in `bootstrap.stepFrame()`) so integration tests that inspect drained events can still call `stepFrame` directly.
- **Risks**: Low — the changes are narrow and well-scoped. Existing integration tests continue to pass.

---

Closes #129
Closes #114
Closes #137
