### PR TITLE
fix(C-05): adapter cleanup — SEC-01, SEC-07, DEAD-39

### DIFF
--- a/src/adapters/dom/hud-adapter.js
+++ b/src/adapters/dom/hud-adapter.js
@@ -25,11 +25,17 @@
 export const ARIA_LIVE_THROTTLE_MS = 1000;
 
 function getNow() {
+  // ARIA throttling must compare timestamps from a single monotonic time base.
+  // Mixing performance.now() with Date.now() yields meaningless intervals (the
+  // two clocks have unrelated origins), so we standardize on performance.now()
+  // and never fall back to Date.now(). When performance.now() is unavailable we
+  // return null so the caller skips throttling and always announces — favouring
+  // accessibility over throttling on hosts that lack a high-resolution clock.
   if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
     return performance.now();
   }
 
-  return Date.now();
+  return null;
 }
 
 function setTextContentIfChanged(element, value) {
@@ -142,12 +148,15 @@ export function createHudAdapter(rootElement) {
 
     const statusMessage = buildStatusMessage(previousState, lives, score, timer, level);
     const now = getNow();
+    // A null clock (no performance.now) means we cannot throttle reliably, so
+    // announce every change rather than mixing in an unrelated time base.
+    const throttleWindowElapsed = now === null || now - lastAnnouncedAt >= ARIA_LIVE_THROTTLE_MS;
 
     if (
       elements.status &&
       statusMessage &&
       statusMessage !== lastAnnouncement &&
-      now - lastAnnouncedAt >= ARIA_LIVE_THROTTLE_MS
+      throttleWindowElapsed
     ) {
       setTextContentIfChanged(elements.status, statusMessage);
       lastAnnouncement = statusMessage;

--- a/src/adapters/io/audio-integration.js
+++ b/src/adapters/io/audio-integration.js
@@ -60,6 +60,7 @@
 
 import { drain } from '../../ecs/resources/event-queue.js';
 import { GAME_STATE } from '../../ecs/resources/game-status.js';
+import { isDevelopment } from '../../shared/env.js';
 
 /**
  * Canonical event type → SFX cue id table.
@@ -136,16 +137,6 @@ export function resolveMusicForState(gameState) {
   return Object.hasOwn(MUSIC_STATE_MAPPING, gameState) ? MUSIC_STATE_MAPPING[gameState] : null;
 }
 
-function isDev() {
-  // Detect Node / Vitest dev-mode without crashing in browser bundles where
-  // `process` is undefined.
-  try {
-    return typeof process !== 'undefined' && process.env && process.env.NODE_ENV !== 'production';
-  } catch {
-    return false;
-  }
-}
-
 /**
  * Create the C-07 audio cue runner.
  *
@@ -173,7 +164,7 @@ export function createAudioCueRunner(options = {}) {
   let lastState = null;
 
   function maybeWarnUnknown(type) {
-    if (!warnUnknownEvents || !isDev()) {
+    if (!warnUnknownEvents || !isDevelopment()) {
       return;
     }
     if (warnedUnknown.has(type)) {

--- a/src/adapters/io/storage-adapter.js
+++ b/src/adapters/io/storage-adapter.js
@@ -1,9 +1,10 @@
 /**
  * Storage adapter for local persistence behind a guarded JSON boundary.
- * Public API: safeRead(key, schema, defaultValue), safeWrite(key, value),
+ * Public API: safeRead(key, validate, defaultValue), safeWrite(key, value),
  * saveHighScore(score), getHighScore().
- * Notes: This module avoids DOM usage, treats storage as untrusted input, and
- * leaves JSON Schema 2020-12 validation as a follow-up integration step.
+ * Notes: This module avoids DOM usage and treats storage as untrusted input.
+ * Callers pass a `validate(value) => boolean` predicate so the adapter rejects
+ * any payload that parses to an object but fails the caller's shape contract.
  */
 export const HIGH_SCORE_STORAGE_KEY = 'ms-ghostman.highScore';
 
@@ -15,7 +16,19 @@ function getStorage() {
   return localStorage;
 }
 
-export function safeRead(key, _schema, defaultValue) {
+/**
+ * Read and parse a JSON value from storage, treating its contents as untrusted.
+ *
+ * @param {string} key Storage key to read.
+ * @param {((value: unknown) => boolean) | null} validate Optional predicate
+ *   that returns `true` when the parsed value satisfies the caller's shape
+ *   contract. When omitted (`null`/`undefined`) only the base object-shape
+ *   guard is applied.
+ * @param {*} defaultValue Value returned when the key is absent, unreadable, or
+ *   fails validation.
+ * @returns {*} The validated parsed value, or `defaultValue`.
+ */
+export function safeRead(key, validate, defaultValue) {
   try {
     const storage = getStorage();
     const rawValue = storage?.getItem(key) ?? null;
@@ -31,7 +44,10 @@ export function safeRead(key, _schema, defaultValue) {
       return defaultValue;
     }
 
-    // TODO: Validate parsedValue against schema using JSON Schema 2020-12.
+    if (typeof validate === 'function' && !validate(parsedValue)) {
+      console.warn(`[storage] Value for key "${key}" failed validation.`);
+      return defaultValue;
+    }
 
     return parsedValue;
   } catch (error) {
@@ -68,13 +84,12 @@ export function saveHighScore(score) {
   }
 }
 
-export function getHighScore() {
-  const parsedValue = safeRead(HIGH_SCORE_STORAGE_KEY, null, { score: 0 });
+function isHighScorePayload(value) {
+  return typeof value.score === 'number' && Number.isFinite(value.score);
+}
 
-  if (typeof parsedValue.score !== 'number' || !Number.isFinite(parsedValue.score)) {
-    console.warn(`[storage] Invalid high score payload for key "${HIGH_SCORE_STORAGE_KEY}".`);
-    return 0;
-  }
+export function getHighScore() {
+  const parsedValue = safeRead(HIGH_SCORE_STORAGE_KEY, isHighScorePayload, { score: 0 });
 
   return Math.max(0, Math.floor(parsedValue.score));
 }

--- a/tests/integration/adapters/audio-integration.test.js
+++ b/tests/integration/adapters/audio-integration.test.js
@@ -66,6 +66,7 @@ beforeEach(() => {
 
 afterEach(() => {
   consoleWarnSpy.mockRestore();
+  vi.unstubAllGlobals();
 });
 
 describe('audio-integration: cue mapping table', () => {
@@ -198,6 +199,12 @@ describe('audio-integration: cue runner — event consumption', () => {
   });
 
   it('drops unknown event types without throwing and warns once per type in dev', () => {
+    // The unknown-event warning is gated behind the shared isDevelopment()
+    // probe, which is true only when NODE_ENV is explicitly 'development'.
+    // Stub it here so the test asserts dev-only warning behavior regardless of
+    // the ambient NODE_ENV the runner happens to execute under.
+    vi.stubGlobal('process', { env: { NODE_ENV: 'development' } });
+
     const audio = createAudioAdapterSpy();
     const eventQueue = createEventQueue();
     const gameStatus = createGameStatus(GAME_STATE.PLAYING);

--- a/tests/integration/adapters/hud-adapter.test.js
+++ b/tests/integration/adapters/hud-adapter.test.js
@@ -349,7 +349,7 @@ describe('hud-adapter', () => {
 
   it('always announces (never throttles via Date.now) when performance.now is unavailable', () => {
     // SEC-07: the adapter must not mix performance.now() with Date.now(); when
-    // the high-resolution clock is missing, getNow() returns 0 so every status
+    // the high-resolution clock is missing, getNow() returns null so every status
     // change is announced rather than throttled against an unrelated time base.
     const originalPerformance = globalThis.performance;
     const dateNowSpy = vi.spyOn(Date, 'now');

--- a/tests/integration/adapters/hud-adapter.test.js
+++ b/tests/integration/adapters/hud-adapter.test.js
@@ -347,11 +347,12 @@ describe('hud-adapter', () => {
     expect(level.element.textContent).toBe('Level: 1');
   });
 
-  it('falls back to Date.now when performance.now is unavailable', () => {
+  it('always announces (never throttles via Date.now) when performance.now is unavailable', () => {
+    // SEC-07: the adapter must not mix performance.now() with Date.now(); when
+    // the high-resolution clock is missing, getNow() returns 0 so every status
+    // change is announced rather than throttled against an unrelated time base.
     const originalPerformance = globalThis.performance;
     const dateNowSpy = vi.spyOn(Date, 'now');
-    dateNowSpy.mockReturnValueOnce(2500);
-    dateNowSpy.mockReturnValueOnce(4000);
     Object.defineProperty(globalThis, 'performance', {
       configurable: true,
       value: undefined,
@@ -364,6 +365,8 @@ describe('hud-adapter', () => {
     adapter.update({ lives: 0, score: 0, timer: 9, bombs: 0, fire: 0, level: 1 });
 
     expect(entries.status.element.textContent).toContain('Lives 0');
+    // Date.now() must never be consulted for ARIA throttling.
+    expect(dateNowSpy).not.toHaveBeenCalled();
 
     Object.defineProperty(globalThis, 'performance', {
       configurable: true,

--- a/tests/integration/adapters/storage-adapter.test.js
+++ b/tests/integration/adapters/storage-adapter.test.js
@@ -91,6 +91,27 @@ describe('storage-adapter', () => {
     expect(console.warn).toHaveBeenCalled();
   });
 
+  it('returns the default value and warns when the validate predicate rejects the value', () => {
+    localStorage.setItem('typed', JSON.stringify({ score: 10 }));
+
+    const validate = vi.fn(() => false);
+    const result = safeRead('typed', validate, { score: 0 });
+
+    expect(result).toEqual({ score: 0 });
+    expect(validate).toHaveBeenCalledWith({ score: 10 });
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it('returns the parsed value when the validate predicate accepts it', () => {
+    localStorage.setItem('typed', JSON.stringify({ score: 10 }));
+
+    const validate = vi.fn(() => true);
+    const result = safeRead('typed', validate, { score: 0 });
+
+    expect(result).toEqual({ score: 10 });
+    expect(validate).toHaveBeenCalledWith({ score: 10 });
+  });
+
   it('stores a JSON string during safeWrite', () => {
     safeWrite('test', { score: 5 });
 


### PR DESCRIPTION
# 🧹 Track C (C-05): Adapter cleanup — SEC-01, SEC-07, DEAD-39

> **Summary**: Three small, self-contained `src/adapters/` fixes — real schema validation in the storage boundary, a single-time-base HUD ARIA throttle, and de-duplication of the dev-mode probe.

---

## 📝 What Changed

### 🔒 SEC-01 (#160) — `storage-adapter.safeRead()` now validates
- The previously-unused `_schema` parameter becomes a `validate(value) => boolean` predicate. When provided, a value that parses to an object but fails the predicate is rejected (warn + `defaultValue`).
- `getHighScore()` now passes `isHighScorePayload`, so untrusted `localStorage` data is validated **inside** the boundary instead of after the read. Satisfies the AGENTS.md "treat storage as untrusted input and validate on read" mandate.
- Backward compatible: all existing callers passed `null` and keep the base object-shape guard.

### ♿ SEC-07 (#166) — HUD ARIA throttle uses one monotonic clock
- `getNow()` no longer mixes `performance.now()` with `Date.now()` (unrelated clock origins produced meaningless throttle intervals).
- When `performance.now()` is unavailable, `getNow()` returns `null` and the adapter **always announces** rather than throttling against a wrong time base — favouring accessibility.

### 🧽 DEAD-39 (#149) — drop duplicated `isDev()`
- Removed the private `isDev()` in `audio-integration.js`; it now imports the shared `isDevelopment()` from `src/shared/env.js`.
- The unknown-event warning test stubs `NODE_ENV=development` to match the stricter canonical probe (`=== 'development'`, not `!== 'production'`).

---

## ✅ Tests
- Added `safeRead` validate-predicate accept/reject tests.
- Updated the HUD no-high-res-clock test to assert `Date.now()` is never consulted.
- Stubbed dev env in the audio unknown-event warning test.
- Full suite green: **1050 unit + integration tests pass**; Biome clean on all changed files.

Closes #160
Closes #166
Closes #149