### PR TITLE
docs(C): annotate test-only HUD exports @internal — DEAD-20, DEAD-21

### DIFF
--- a/src/adapters/dom/hud-adapter.js
+++ b/src/adapters/dom/hud-adapter.js
@@ -22,6 +22,12 @@
  *   not spam on every render tick.
  */
 
+/**
+ * Throttle window for ARIA live-region announcements.
+ *
+ * @internal Exported for tests only; not part of the adapter's public API
+ *   (`createHudAdapter`). Production code must not import this.
+ */
 export const ARIA_LIVE_THROTTLE_MS = 1000;
 
 function getNow() {
@@ -55,14 +61,26 @@ function resolveValueNode(element) {
   return element;
 }
 
+/**
+ * @internal Exported for tests only; not part of the adapter's public API
+ *   (`createHudAdapter`). Production code must not import this.
+ */
 export function formatLives(lives) {
   return '❤️'.repeat(Math.max(0, lives));
 }
 
+/**
+ * @internal Exported for tests only; not part of the adapter's public API
+ *   (`createHudAdapter`). Production code must not import this.
+ */
 export function formatScore(score) {
   return String(Math.max(0, score)).padStart(5, '0');
 }
 
+/**
+ * @internal Exported for tests only; not part of the adapter's public API
+ *   (`createHudAdapter`). Production code must not import this.
+ */
 export function formatTimer(totalSeconds) {
   const safeSeconds = Math.max(0, totalSeconds);
   const minutes = Math.floor(safeSeconds / 60);


### PR DESCRIPTION
# 🧽 Track C: DEAD-20 / DEAD-21 — HUD adapter test-only exports

> Part of #142 (Unused/Minor Exports). Track C portion only.

## What & why
`hud-adapter.js` exports four symbols that are imported **only by tests**, never by production `src/`:

| ID | Symbol(s) |
|----|-----------|
| DEAD-20 | `formatLives`, `formatScore`, `formatTimer` |
| DEAD-21 | `ARIA_LIVE_THROTTLE_MS` |

The tests genuinely need the exports, so rather than removing them (which would break `tests/integration/adapters/hud-adapter.test.js`), each is annotated `@internal` to document that the adapter's public surface is just `createHudAdapter`. Zero runtime change.

## Scope note
DEAD-27 (`storage-adapter.js`: `HIGH_SCORE_STORAGE_KEY`, `safeRead`, `safeWrite`) is the **third** Track C item in #142 but is intentionally **left out** here: PR #202 changes `safeRead`'s signature (SEC-01), so this annotation is deferred until #202 merges to avoid a conflict.

## Tests
- `npx vitest run tests/integration/adapters/hud-adapter.test.js` → 13/13 pass
- Biome clean on the changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)