### PR TITLE
fix(ghost-ai): fallback speed, null Blinky targeting, hot-path alloc …

### DIFF
--- a/docs/audit-reports/pr-audit-asmyrogl-bugfix-130-135-123.md
+++ b/docs/audit-reports/pr-audit-asmyrogl-bugfix-130-135-123.md
@@ -1,0 +1,49 @@
+# 🛡️ Audit: `asmyrogl/bugfix-130-135-123`
+## 🏁 Verdict: `**FAIL**`
+---
+## 🎯 Scope & Compliance
+- **Ticket ID**: `BUG-17 (#130), BUG-22 (#135), BUG-10 (#123)` → impl ticket `B-08`; `constants.js` = `D-01` | **Track**: `B`
+- **Audit Mode**: `BUGFIX`
+- **Base Comparison**: `merge-base(main, HEAD)=5f1a11b ..HEAD + working tree` (HEAD == merge-base; all changes uncommitted)
+### 📦 Deliverables & Verification
+- ✅ PASS: `BUG-17 — GHOST_DEFAULT_SPEED=4.5 terminal fallback` (constants.js:124; resolveGhostSpeed precedence STUNNED→stored→map→default preserved, ghost-ai-system.js:250-270; movement guard `speed>0` at :948 now satisfied)
+- ✅ PASS: `BUG-22 — findBlinkyTile returns null + Inky chase fallback` (findBlinkyTile null in all 3 paths :592-625; `hasBlinky` gate :820-824; Inky `computeBlinkyTarget` fallback :894-913; no off-map (0,0) targeting; scratch-tile reuse preserved)
+- ✅ PASS: `BUG-10 — module-level scratch Set, clear+refill` (releasedGhostScratch :87; per-frame clear/refill :795-806; null-vs-empty semantics preserved; per-frame `new Set()` removed)
+- ✅ PASS: `New + updated tests` (unit BUG-17/22/10 cases; integration ghost-default-speed-fallback.test.js, inky-without-blinky.test.js; a-05 adapted for BUG-17 — affected suite 50 passed; biome clean on 6 changed files)
+- **Out-of-Scope Findings**: `none` (every hunk maps to BUG-17/22/10; a-05 edit is a required BUG-17 consequence)
+---
+## 🔍 Audit Findings & Blockers
+### 🚨 Critical (Blockers)
+1. **Primary policy gate `npm run policy -- --require-approval=false` returned exit=1.** Root cause is a single E2E assertion `tests/e2e/audit/audit.browser.spec.js:254 › AUDIT-B-05` (long-task threshold: expected `taskCount <= 0`, received `3`). This is **flaky / environment-load-sensitive** — on isolated re-run it PASSES (1 passed, 3.0s vs 15.0s under full-suite contention). It is **unrelated to the audited ghost-AI changes** (it measures main-thread long tasks at runtime boot, not ghost speed/targeting/allocation). Under the canonical rule "PASS requires ALL gates to satisfy requirements," a non-green primary gate forces a strict FAIL even though the changed scope is sound.
+### ⚠️ High/Medium/Low
+1. (Low, cosmetic) `GHOST_DEFAULT_SPEED = 4.5` comment says it "mirrors PLAYER_BASE_SPEED"; 4.5 happens to equal level-2 ghostSpeed (level-1=4.0, level-3=5.0). Any positive finite value satisfies the fix; not a defect.
+2. (Low, informational) Checked-in `.policy-pr-meta.json` was stale (referenced `chbaikas/bugfix-ARCH-01...` / #153) before the run; `run-all.mjs`→`prepare-context.mjs` regenerated it. `changed-files.txt` resolved to 0 files because all changes are uncommitted working-tree, so narrow `--scope=changed` forbidden/header checks scanned 0 files (they still PASSED; repo-scope scans covered 177/70 files clean).
+> [!IMPORTANT]
+> ### ⛑️ Path To PASS (Required if FAIL)
+> 1. Re-run the primary gate to get a clean pass: `npm run policy -- --require-approval=false`. The AUDIT-B-05 long-task assertion is flaky under full-suite load; it passed in isolation (`npx playwright test tests/e2e/audit/audit.browser.spec.js -g "AUDIT-B-05"` → 1 passed). If it recurs, re-run on a quiescent machine or quarantine/stabilize that perf threshold separately — it is owned by the audit/perf suite, NOT by this bugfix scope.
+> 2. (Optional, not blocking) Commit the working-tree changes so policy narrow `--scope=changed` checks exercise the actual changed files instead of 0.
+---
+## 📋 Requirements, Audit & Drift
+- **REQ IDs**: `REQ-14, REQ-15` | **AUDIT IDs**: `AUDIT-F-06, AUDIT-F-13` (B-08 mappings already in audit-traceability-matrix.md:64-65,80,87)
+- ✅ PASS: Coverage evidence status — B-08 REQ/AUDIT pre-mapped; new BUG-specific tests add direct coverage; bugfix branch needs no new matrix rows (matrix is REQ→AUDIT→ticket→test, not per-bug)
+- ✅ PASS (N/A): Manual evidence status (F-19/20/21/B-06) — deterministic logic fixes; no perf-trace artifact required for allocation-reducing, non-rendering change
+- ✅ PASS: Feature/Technical Drift Assessment — no drift; fixes degrade gracefully toward documented genre behavior (game-description.md §5.1) and reinforce AGENTS.md no-silent-failure + no-hot-loop-allocation rules
+---
+## 🛠️ Automated Gate Summary
+- ❌ FAIL: `npm run policy -- --require-approval=false` (exit=1, duration=136s) — failure isolated to Phase 1 `policy:quality` → `test:e2e` → AUDIT-B-05 flaky long-task assertion. All policy-specific enforcements PASSED: policy:checks (bugfix-mode ownership bypass), policy:forbidden, policy:header, policy:trace, policy:approve(skipped).
+- ✅ PASS: Verification pass — re-ran the sole failing test once in isolation: `npx playwright test ... -g "AUDIT-B-05"` → **1 passed (3.0s)**, confirming non-reproducible under normal load (flaky, environment-sensitive). No failure-isolation needed for policy:checks/forbidden/header/trace — those passed in the primary run.
+---
+## ✅ Policy Matrix
+- ✅ PASS: Ticket/Track Context Valid (BUGFIX mode detected, owner=asmyrogl ∈ registered, Track B)
+- ✅ PASS: Ownership & PR Template Respected (bugfix ownership bypass; cross-track B+D allowed)
+- ✅ PASS: ECS DOM Boundary & Adapter Injection (no DOM, no adapter imports in changed scope)
+- ✅ PASS: Forbidden Tech (canvas/WebGL/frameworks) (static scan + policy:forbidden clean)
+- ✅ PASS: Security Sinks (innerHTML/eval/timers) (none introduced)
+- ✅ PASS: Timing, Input, & Rendering Invariants (untouched)
+- ✅ PASS: New Files Header Comments (both new test files have `/** ... */` block headers; tests/ not gated by header check)
+- ✅ PASS: Audit Traceability Matrix Mapping (B-08→REQ-14/15, AUDIT-F-06/F-13 present; policy:trace passed)
+- ✅ PASS: No Gameplay/Document/Technical Drift
+---
+## 📄 Final Report Metadata
+- **Date**: 2026-06-09
+- **READY_FOR_MAIN**: `**NO**`

--- a/src/ecs/resources/constants.js
+++ b/src/ecs/resources/constants.js
@@ -116,6 +116,13 @@ export const LEVEL_TIMERS = [120, 180, 240];
 /** Stunned ghost speed (constant across all levels). */
 export const GHOST_STUNNED_SPEED = 2.0;
 
+/** Safety fallback ghost speed (tiles/sec) used by ghost-ai-system.js when
+ *  neither the per-entity speed nor the map's `ghostSpeed` resolves to a
+ *  positive number. Mirrors the PLAYER_BASE_SPEED fallback in
+ *  player-move-system.js so a missing/non-positive map speed can never freeze a
+ *  ghost on its tile (BUG-17). */
+export const GHOST_DEFAULT_SPEED = 4.5;
+
 /** Total number of levels in the game. */
 export const TOTAL_LEVELS = 3;
 

--- a/src/ecs/resources/constants.js
+++ b/src/ecs/resources/constants.js
@@ -118,9 +118,11 @@ export const GHOST_STUNNED_SPEED = 2.0;
 
 /** Safety fallback ghost speed (tiles/sec) used by ghost-ai-system.js when
  *  neither the per-entity speed nor the map's `ghostSpeed` resolves to a
- *  positive number. Mirrors the PLAYER_BASE_SPEED fallback in
- *  player-move-system.js so a missing/non-positive map speed can never freeze a
- *  ghost on its tile (BUG-17). */
+ *  positive number. Acts as the same kind of terminal guard PLAYER_BASE_SPEED
+ *  provides in player-move-system.js so a missing/non-positive map speed can
+ *  never freeze a ghost on its tile (BUG-17). The 4.5 value is the canonical
+ *  mid (level-2) ghost speed — a sensible neutral default between the level-1
+ *  (4.0) and level-3 (5.0) map speeds. */
 export const GHOST_DEFAULT_SPEED = 4.5;
 
 /** Total number of levels in the game. */

--- a/src/ecs/systems/ghost-ai-system.js
+++ b/src/ecs/systems/ghost-ai-system.js
@@ -18,6 +18,8 @@
  * - computePinkyTarget(playerTile, playerVector): four tiles ahead of player.
  * - computeInkyTarget(playerTile, playerVector, blinkyTile): doubled-vector flank.
  * - computeClydeTarget(playerTile, ghostTile, mapResource): chase/retreat toggle.
+ * - findBlinkyTile(ghostStore, positionStore, ghostEntityIds, reusableTile):
+ *   Blinky's tile, or null when no BLINKY ghost is active.
  * - resolveGhostTargetTile(ghostType, context): canonical target for a ghost type.
  * - selectGhostDirection(context): pick a passable direction this step.
  * - resolveGhostSpeed(ghostStore, ghostId, mapResource): effective speed.
@@ -48,6 +50,7 @@
 import { COMPONENT_MASK } from '../components/registry.js';
 import {
   CLYDE_DISTANCE_THRESHOLD,
+  GHOST_DEFAULT_SPEED,
   GHOST_STATE,
   GHOST_STUNNED_SPEED,
   GHOST_TYPE,
@@ -70,6 +73,18 @@ const DEFAULT_RNG_RESOURCE_KEY = 'rng';
 
 const MAX_DELTA_MS = 1000;
 const MOVEMENT_EPSILON = 1e-9;
+
+/**
+ * Module-level scratch set for the released-ghost lookup. Reused (cleared +
+ * refilled) every frame instead of allocating `new Set(...)` per tick, which
+ * created steady GC pressure in the hot simulation loop (BUG-10). It is safe as
+ * a module singleton even if multiple ghost-ai systems exist in one world: each
+ * system's `update` runs synchronously start-to-finish, refilling the set from
+ * its own spawn state and consuming it within the same tick before any other
+ * system can touch it. It is never retained across frames or read after the
+ * loop, so determinism is unchanged.
+ */
+const releasedGhostScratch = new Set();
 
 /**
  * Canonical component query for ghost AI.
@@ -249,7 +264,10 @@ export function resolveGhostSpeed(ghostStore, ghostId, mapResource) {
     return mapSpeed;
   }
 
-  return 0;
+  // Terminal fallback: a missing/non-positive stored AND map speed must never
+  // resolve to 0, or the movement guard (speed > 0) would freeze the ghost on
+  // its tile permanently (BUG-17). Mirrors the PLAYER_BASE_SPEED safety net.
+  return GHOST_DEFAULT_SPEED;
 }
 
 /**
@@ -585,19 +603,35 @@ function readPlayerVector(velocityStore, playerEntityId) {
   return { rowDelta, colDelta };
 }
 
-function findBlinkyTile(ghostStore, positionStore, ghostEntityIds, reusableTile) {
+/**
+ * Find the current tile of the BLINKY ghost, if one is active.
+ *
+ * Returns `null` when no BLINKY entity is present (BUG-22). Callers MUST treat a
+ * null result as "Blinky absent" and route Inky through a direct chase instead
+ * of the doubled-vector flank — a previous `{ row: 0, col: 0 }` fallback made
+ * Inky silently flank off the map origin.
+ *
+ * @param {{ type?: Uint8Array } | null} ghostStore - Ghost component store.
+ * @param {object | null} positionStore - Position component store.
+ * @param {Iterable<number>} ghostEntityIds - Active ghost entity slots.
+ * @param {{ row: number, col: number }} reusableTile - Scratch tile reused to
+ *   avoid per-call allocation while reading the position store.
+ * @returns {{ row: number, col: number } | null} Blinky's tile, or null when no
+ *   BLINKY entity is active.
+ */
+export function findBlinkyTile(ghostStore, positionStore, ghostEntityIds, reusableTile) {
   if (!ghostStore || !positionStore) {
-    return { row: 0, col: 0 };
+    return null;
   }
 
   for (const ghostId of ghostEntityIds) {
     if (ghostStore.type?.[ghostId] === GHOST_TYPE.BLINKY) {
       const tile = readEntityTile(positionStore, ghostId, reusableTile);
-      return tile ? { row: tile.row, col: tile.col } : { row: 0, col: 0 };
+      return tile ? { row: tile.row, col: tile.col } : null;
     }
   }
 
-  return { row: 0, col: 0 };
+  return null;
 }
 
 function snapGhostToTarget(positionStore, velocityStore, ghostId) {
@@ -758,9 +792,18 @@ export function createGhostAiSystem(options = {}) {
         ? readBombOccupancyCells(world.getResource(bombOccupancyResourceKey), mapResource)
         : null;
       const spawnState = spawnResourceKey ? world.getResource(spawnResourceKey) : null;
-      const releasedGhostSet = spawnState?.releasedGhostIds
-        ? new Set(spawnState.releasedGhostIds)
-        : null;
+      // Reuse the module-level scratch set to avoid a per-frame `new Set()`
+      // allocation in this hot loop (BUG-10). Keep the original null-vs-empty
+      // semantics: a missing `releasedGhostIds` yields a null set (revive branch
+      // disabled), while a present-but-empty list yields a cleared scratch set.
+      let releasedGhostSet = null;
+      if (spawnState?.releasedGhostIds) {
+        releasedGhostScratch.clear();
+        for (const releasedId of spawnState.releasedGhostIds) {
+          releasedGhostScratch.add(releasedId);
+        }
+        releasedGhostSet = releasedGhostScratch;
+      }
 
       const playerEntityId =
         playerEntity && Number.isInteger(playerEntity.id) && playerEntity.id >= 0
@@ -778,10 +821,15 @@ export function createGhostAiSystem(options = {}) {
       const ghostEntityIds = typeof world.query === 'function' ? world.query(requiredMask) : [];
 
       // Resolve Blinky's tile once per step so Inky's targeting stays
-      // deterministic across the iteration order.
+      // deterministic across the iteration order. When Blinky is absent
+      // (not in activeGhostTypes), the snapshot is null: Inky must NOT flank off
+      // a bogus (0,0) tile, so it falls back to a direct chase below (BUG-22).
       const blinkySnapshot = findBlinkyTile(ghostStore, positionStore, ghostEntityIds, blinkyTile);
-      blinkyTile.row = blinkySnapshot.row;
-      blinkyTile.col = blinkySnapshot.col;
+      const hasBlinky = blinkySnapshot !== null;
+      if (hasBlinky) {
+        blinkyTile.row = blinkySnapshot.row;
+        blinkyTile.col = blinkySnapshot.col;
+      }
 
       const deltaSeconds = readDeltaMs(context) / 1000;
 
@@ -849,6 +897,11 @@ export function createGhostAiSystem(options = {}) {
               row: mapResource.ghostSpawnRow ?? currentTile.row,
               col: mapResource.ghostSpawnCol ?? currentTile.col,
             };
+          } else if (ghostType === GHOST_TYPE.INKY && !hasBlinky) {
+            // Inky's flank target depends on Blinky's tile; with Blinky absent
+            // there is no valid reference, so chase the player directly like
+            // Blinky instead of flanking off a bogus origin tile (BUG-22).
+            targetTile = computeBlinkyTarget(playerTile);
           } else {
             targetTile = resolveGhostTargetTile(ghostType, {
               ghostTile: currentTile,

--- a/tests/integration/gameplay/a-05-integration.test.js
+++ b/tests/integration/gameplay/a-05-integration.test.js
@@ -449,11 +449,7 @@ describe('A-05 event ordering integration', () => {
     try {
       const bootstrap = createBootstrap({
         boardContainerElement: gameBoard,
-        loadMapForLevel: () => {
-          const map = createRuntimeMapResource();
-          map.ghostSpeed = 0;
-          return map;
-        },
+        loadMapForLevel: () => createRuntimeMapResource(),
         now: 0,
       });
       const inputAdapter = createRuntimeInputAdapterStub();
@@ -500,8 +496,14 @@ describe('A-05 event ordering integration', () => {
       const eventQueue = world.getResource('eventQueue');
       drain(eventQueue);
 
+      // Keep this dummy ghost stationary on the bomb's blast tile so the
+      // explosion is guaranteed to catch it. We re-pin it each frame instead of
+      // relying on a zero map ghostSpeed: after the BUG-17 fix a non-positive
+      // speed falls back to GHOST_DEFAULT_SPEED, so a zero speed no longer
+      // freezes a ghost in place.
       let nowMs = 0;
       for (let step = 1; step <= 190; step++) {
+        placeEntity(positionStore, ghostHandle.id, 3, 4);
         nowMs += FIXED_DT_MS;
         bootstrap.stepFrame(nowMs);
       }

--- a/tests/integration/gameplay/ghost-default-speed-fallback.test.js
+++ b/tests/integration/gameplay/ghost-default-speed-fallback.test.js
@@ -1,0 +1,129 @@
+/**
+ * BUG-17 integration: ghost keeps moving without a configured ghost speed.
+ *
+ * Reproduces the freeze reported in issue #130: when a map omits `ghostSpeed`
+ * and no per-entity speed is configured, `resolveGhostSpeed` previously returned
+ * 0, the movement guard (`speed > 0`) skipped advancing the ghost, and the ghost
+ * froze on its spawn tile forever. This test bootstraps a minimal ECS world with
+ * NO ghost speed anywhere, runs ~60 simulation steps, and asserts the ghost's
+ * position actually advances — proving the terminal `GHOST_DEFAULT_SPEED`
+ * fallback keeps the AI moving.
+ *
+ * The harness mirrors the unit-test bootstrap style (direct World + component
+ * stores) rather than the full game bootstrap, because we need precise control
+ * over leaving `ghostSpeed` undefined while keeping every other resource valid.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createGhostStore, createPlayerStore } from '../../../src/ecs/components/actors.js';
+import { COMPONENT_MASK } from '../../../src/ecs/components/registry.js';
+import { createPositionStore, createVelocityStore } from '../../../src/ecs/components/spatial.js';
+import { FIXED_DT_MS, GHOST_STATE, GHOST_TYPE } from '../../../src/ecs/resources/constants.js';
+import { createGameStatus, GAME_STATE } from '../../../src/ecs/resources/game-status.js';
+import { createMapResource } from '../../../src/ecs/resources/map-resource.js';
+import {
+  createGhostAiSystem,
+  GHOST_AI_REQUIRED_MASK,
+} from '../../../src/ecs/systems/ghost-ai-system.js';
+import { World } from '../../../src/ecs/world/world.js';
+
+// Open 9x9 map. Critically, `metadata` omits `ghostSpeed`, so the derived
+// `mapResource.ghostSpeed` is undefined — the BUG-17 trigger condition.
+function createNoSpeedMap() {
+  return {
+    level: 1,
+    metadata: {
+      name: 'No Ghost Speed Harness',
+      timerSeconds: 120,
+      maxGhosts: 4,
+      // ghostSpeed intentionally omitted.
+      activeGhostTypes: [0, 1, 2, 3],
+    },
+    dimensions: { rows: 9, columns: 9 },
+    grid: [
+      [1, 1, 1, 1, 1, 1, 1, 1, 1],
+      [1, 0, 0, 0, 0, 0, 0, 0, 1],
+      [1, 0, 1, 0, 0, 0, 1, 0, 1],
+      [1, 0, 0, 0, 6, 0, 0, 0, 1],
+      [1, 0, 0, 5, 5, 5, 0, 0, 1],
+      [1, 0, 0, 5, 5, 5, 0, 0, 1],
+      [1, 0, 1, 0, 0, 0, 1, 0, 1],
+      [1, 0, 0, 0, 0, 0, 0, 0, 1],
+      [1, 1, 1, 1, 1, 1, 1, 1, 1],
+    ],
+    spawn: {
+      player: { row: 3, col: 4 },
+      ghostHouse: { topRow: 4, bottomRow: 5, leftCol: 3, rightCol: 5 },
+      ghostSpawnPoint: { row: 4, col: 4 },
+    },
+  };
+}
+
+function buildWorld() {
+  const world = new World();
+  const ghostStore = createGhostStore(16);
+  const positionStore = createPositionStore(16);
+  const velocityStore = createVelocityStore(16);
+  const playerStore = createPlayerStore(16);
+  const mapResource = createMapResource(createNoSpeedMap());
+
+  const playerEntity = world.createEntity(COMPONENT_MASK.PLAYER | COMPONENT_MASK.POSITION);
+  positionStore.row[playerEntity.id] = mapResource.playerSpawnRow;
+  positionStore.col[playerEntity.id] = mapResource.playerSpawnCol;
+  positionStore.targetRow[playerEntity.id] = mapResource.playerSpawnRow;
+  positionStore.targetCol[playerEntity.id] = mapResource.playerSpawnCol;
+
+  // Single Blinky ghost placed in an open corridor tile, NOT in the ghost house,
+  // so it has legal moves the moment the system ticks.
+  const ghost = world.createEntity(GHOST_AI_REQUIRED_MASK);
+  ghostStore.type[ghost.id] = GHOST_TYPE.BLINKY;
+  ghostStore.state[ghost.id] = GHOST_STATE.NORMAL;
+  ghostStore.timerMs[ghost.id] = 0;
+  ghostStore.speed[ghost.id] = 0; // no per-entity speed: relies on the fallback
+  positionStore.row[ghost.id] = 1;
+  positionStore.col[ghost.id] = 5;
+  positionStore.prevRow[ghost.id] = 1;
+  positionStore.prevCol[ghost.id] = 5;
+  positionStore.targetRow[ghost.id] = 1;
+  positionStore.targetCol[ghost.id] = 5;
+
+  world.setResource('ghost', ghostStore);
+  world.setResource('position', positionStore);
+  world.setResource('velocity', velocityStore);
+  world.setResource('player', playerStore);
+  world.setResource('mapResource', mapResource);
+  world.setResource('playerEntity', playerEntity);
+  world.setResource('gameStatus', createGameStatus(GAME_STATE.PLAYING));
+
+  return { world, ghostStore, positionStore, velocityStore, mapResource, ghostId: ghost.id };
+}
+
+describe('BUG-17 ghost default speed fallback (integration)', () => {
+  it('ghost without configured ghostSpeed still advances over ~60 steps', () => {
+    const { world, positionStore, ghostId, mapResource } = buildWorld();
+    // Confirm the bug's trigger condition is actually present.
+    expect(mapResource.ghostSpeed).toBeUndefined();
+
+    const startRow = positionStore.row[ghostId];
+    const startCol = positionStore.col[ghostId];
+
+    const system = createGhostAiSystem();
+    for (let frame = 0; frame < 60; frame += 1) {
+      system.update({ world, dtMs: FIXED_DT_MS, frame });
+    }
+
+    const moved =
+      positionStore.row[ghostId] !== startRow || positionStore.col[ghostId] !== startCol;
+    expect(moved).toBe(true);
+  });
+
+  it('reports a positive effective speed instead of freezing', () => {
+    const { world, velocityStore, ghostId } = buildWorld();
+
+    const system = createGhostAiSystem();
+    system.update({ world, dtMs: FIXED_DT_MS, frame: 0 });
+
+    // The system writes the resolved speed onto the velocity store each tick.
+    expect(velocityStore.speedTilesPerSecond[ghostId]).toBeGreaterThan(0);
+  });
+});

--- a/tests/integration/gameplay/inky-without-blinky.test.js
+++ b/tests/integration/gameplay/inky-without-blinky.test.js
@@ -1,0 +1,147 @@
+/**
+ * BUG-22 integration: Inky chases the player when Blinky is absent.
+ *
+ * Reproduces issue #135: when BLINKY is not among the active ghosts,
+ * `findBlinkyTile` previously fell through to `{ row: 0, col: 0 }`. Inky's
+ * doubled-vector flank target was then computed off the (0,0) corner, sending
+ * Inky to patrol the top-left edge of the map regardless of where the player is
+ * — a silent mis-targeting bug. The fix makes `findBlinkyTile` return null and
+ * routes Inky through the Blinky-style direct-chase fallback when Blinky is
+ * absent.
+ *
+ * This test bootstraps a minimal ECS world containing ONLY an Inky ghost (no
+ * Blinky), runs several simulation steps with the player far from the (0,0)
+ * corner, and asserts Inky moves toward the player (chases) instead of drifting
+ * toward the origin.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createGhostStore, createPlayerStore } from '../../../src/ecs/components/actors.js';
+import { COMPONENT_MASK } from '../../../src/ecs/components/registry.js';
+import { createPositionStore, createVelocityStore } from '../../../src/ecs/components/spatial.js';
+import { FIXED_DT_MS, GHOST_STATE, GHOST_TYPE } from '../../../src/ecs/resources/constants.js';
+import { createGameStatus, GAME_STATE } from '../../../src/ecs/resources/game-status.js';
+import { createMapResource } from '../../../src/ecs/resources/map-resource.js';
+import {
+  createGhostAiSystem,
+  GHOST_AI_REQUIRED_MASK,
+} from '../../../src/ecs/systems/ghost-ai-system.js';
+import { World } from '../../../src/ecs/world/world.js';
+
+// Open 9x9 map with only non-Blinky ghosts active (Inky present, Blinky absent).
+function createInkyOnlyMap() {
+  return {
+    level: 1,
+    metadata: {
+      name: 'Inky Without Blinky Harness',
+      timerSeconds: 120,
+      maxGhosts: 4,
+      ghostSpeed: 4.0,
+      activeGhostTypes: [GHOST_TYPE.PINKY, GHOST_TYPE.INKY, GHOST_TYPE.CLYDE],
+    },
+    dimensions: { rows: 9, columns: 9 },
+    grid: [
+      [1, 1, 1, 1, 1, 1, 1, 1, 1],
+      [1, 0, 0, 0, 0, 0, 0, 0, 1],
+      [1, 0, 1, 0, 0, 0, 1, 0, 1],
+      [1, 0, 0, 0, 6, 0, 0, 0, 1],
+      [1, 0, 0, 5, 5, 5, 0, 0, 1],
+      [1, 0, 0, 5, 5, 5, 0, 0, 1],
+      [1, 0, 1, 0, 0, 0, 1, 0, 1],
+      [1, 0, 0, 0, 0, 0, 0, 0, 1],
+      [1, 1, 1, 1, 1, 1, 1, 1, 1],
+    ],
+    spawn: {
+      player: { row: 3, col: 6 },
+      ghostHouse: { topRow: 4, bottomRow: 5, leftCol: 3, rightCol: 5 },
+      ghostSpawnPoint: { row: 4, col: 4 },
+    },
+  };
+}
+
+function buildWorld() {
+  const world = new World();
+  const ghostStore = createGhostStore(16);
+  const positionStore = createPositionStore(16);
+  const velocityStore = createVelocityStore(16);
+  const playerStore = createPlayerStore(16);
+  const mapResource = createMapResource(createInkyOnlyMap());
+
+  // Player parked at (3,6), an open tile. When Blinky is absent the buggy
+  // doubled-vector flank computes Inky's target as 2 × playerTile reflected
+  // about the (0,0) origin — i.e. roughly (6,12), off the map to the
+  // bottom-right — which steers Inky AWAY from a player sitting up-and-left of
+  // the ghost. The corrected chase fallback instead targets the player tile
+  // directly, so Inky converges on the player.
+  const playerEntity = world.createEntity(COMPONENT_MASK.PLAYER | COMPONENT_MASK.POSITION);
+  const playerRow = 3;
+  const playerCol = 6;
+  positionStore.row[playerEntity.id] = playerRow;
+  positionStore.col[playerEntity.id] = playerCol;
+  positionStore.targetRow[playerEntity.id] = playerRow;
+  positionStore.targetCol[playerEntity.id] = playerCol;
+
+  // Single Inky ghost starting beyond the player from the origin (bottom-right
+  // open area), so the buggy origin-reflected target and the correct chase
+  // target lie on OPPOSITE sides of Inky — making the two behaviors diverge.
+  const inky = world.createEntity(GHOST_AI_REQUIRED_MASK);
+  ghostStore.type[inky.id] = GHOST_TYPE.INKY;
+  ghostStore.state[inky.id] = GHOST_STATE.NORMAL;
+  ghostStore.timerMs[inky.id] = 0;
+  ghostStore.speed[inky.id] = 4.0;
+  const inkyStartRow = 7;
+  const inkyStartCol = 7;
+  positionStore.row[inky.id] = inkyStartRow;
+  positionStore.col[inky.id] = inkyStartCol;
+  positionStore.prevRow[inky.id] = inkyStartRow;
+  positionStore.prevCol[inky.id] = inkyStartCol;
+  positionStore.targetRow[inky.id] = inkyStartRow;
+  positionStore.targetCol[inky.id] = inkyStartCol;
+
+  world.setResource('ghost', ghostStore);
+  world.setResource('position', positionStore);
+  world.setResource('velocity', velocityStore);
+  world.setResource('player', playerStore);
+  world.setResource('mapResource', mapResource);
+  world.setResource('playerEntity', playerEntity);
+  world.setResource('gameStatus', createGameStatus(GAME_STATE.PLAYING));
+
+  return {
+    world,
+    ghostStore,
+    positionStore,
+    inkyId: inky.id,
+    playerRow,
+    playerCol,
+    inkyStartRow,
+    inkyStartCol,
+  };
+}
+
+function distanceToPlayer(positionStore, ghostId, playerRow, playerCol) {
+  const dRow = positionStore.row[ghostId] - playerRow;
+  const dCol = positionStore.col[ghostId] - playerCol;
+  return Math.hypot(dRow, dCol);
+}
+
+describe('BUG-22 Inky chases when Blinky is absent (integration)', () => {
+  it('Inky moves toward the player instead of flanking off a bogus (0,0) Blinky tile', () => {
+    const { world, positionStore, inkyId, playerRow, playerCol } = buildWorld();
+
+    const startDistance = distanceToPlayer(positionStore, inkyId, playerRow, playerCol);
+
+    const system = createGhostAiSystem();
+    for (let frame = 0; frame < 60; frame += 1) {
+      system.update({ world, dtMs: FIXED_DT_MS, frame });
+    }
+
+    const endDistance = distanceToPlayer(positionStore, inkyId, playerRow, playerCol);
+
+    // Chase behavior: Inky closes in on the player and ends up adjacent to it.
+    // Under the bug, the doubled-vector flank target reflected about (0,0)
+    // (≈ (6,12), off-map) walls Inky off ~2+ tiles short of the player, so this
+    // tight threshold fails. The chase fallback brings it within one tile.
+    expect(endDistance).toBeLessThan(startDistance);
+    expect(endDistance).toBeLessThanOrEqual(1.5);
+  });
+});

--- a/tests/unit/systems/ghost-ai-system.test.js
+++ b/tests/unit/systems/ghost-ai-system.test.js
@@ -15,6 +15,7 @@ import { createPositionStore, createVelocityStore } from '../../../src/ecs/compo
 import {
   CLYDE_DISTANCE_THRESHOLD,
   FIXED_DT_MS,
+  GHOST_DEFAULT_SPEED,
   GHOST_STATE,
   GHOST_STUNNED_SPEED,
   GHOST_TYPE,
@@ -28,6 +29,7 @@ import {
   computeInkyTarget,
   computePinkyTarget,
   createGhostAiSystem,
+  findBlinkyTile,
   GHOST_AI_DIRECTIONS,
   GHOST_AI_REQUIRED_MASK,
   GHOST_DIRECTION_VECTOR,
@@ -399,6 +401,63 @@ describe('ghost-ai-system: speed resolution', () => {
     ghostStore.speed[0] = 0;
     expect(resolveGhostSpeed(ghostStore, 0, { ghostSpeed: 4.0 })).toBe(4.0);
   });
+
+  it('fallback speed keeps ghost moving when stored and map speed are missing/non-positive (BUG-17)', () => {
+    // Terminal fallback: when neither the per-entity speed nor the map ghost
+    // speed yields a positive number, resolveGhostSpeed must return the safety
+    // default so the movement guard (speed > 0) never freezes the ghost.
+    const ghostStore = createGhostStore(4);
+    ghostStore.state[0] = GHOST_STATE.NORMAL;
+    ghostStore.speed[0] = 0; // no per-entity speed configured
+
+    expect(resolveGhostSpeed(ghostStore, 0, {})).toBe(GHOST_DEFAULT_SPEED);
+    expect(resolveGhostSpeed(ghostStore, 0, { ghostSpeed: 0 })).toBe(GHOST_DEFAULT_SPEED);
+    expect(resolveGhostSpeed(ghostStore, 0, { ghostSpeed: -1 })).toBe(GHOST_DEFAULT_SPEED);
+    expect(resolveGhostSpeed(ghostStore, 0, { ghostSpeed: Number.NaN })).toBe(GHOST_DEFAULT_SPEED);
+    // A null map resource (resource not registered) must also fall back safely.
+    expect(resolveGhostSpeed(ghostStore, 0, null)).toBe(GHOST_DEFAULT_SPEED);
+  });
+
+  it('stunned ghosts still use stunned speed even when no positive speed is configured', () => {
+    // The terminal default must NOT override the stunned-speed precedence.
+    const ghostStore = createGhostStore(4);
+    ghostStore.state[0] = GHOST_STATE.STUNNED;
+    ghostStore.speed[0] = 0;
+    expect(resolveGhostSpeed(ghostStore, 0, {})).toBe(GHOST_STUNNED_SPEED);
+  });
+});
+
+describe('ghost-ai-system: findBlinkyTile (BUG-22)', () => {
+  it('returns the BLINKY tile when a BLINKY ghost is present', () => {
+    const ghostStore = createGhostStore(4);
+    const positionStore = createPositionStore(4);
+    // Two ghosts: id 0 is Pinky, id 1 is Blinky at (3, 7).
+    ghostStore.type[0] = GHOST_TYPE.PINKY;
+    ghostStore.type[1] = GHOST_TYPE.BLINKY;
+    positionStore.row[1] = 3;
+    positionStore.col[1] = 7;
+    positionStore.targetRow[1] = 3;
+    positionStore.targetCol[1] = 7;
+
+    const reusable = { row: 0, col: 0 };
+    expect(findBlinkyTile(ghostStore, positionStore, [0, 1], reusable)).toEqual({ row: 3, col: 7 });
+  });
+
+  it('returns null when no BLINKY entity is present', () => {
+    const ghostStore = createGhostStore(4);
+    const positionStore = createPositionStore(4);
+    // Only non-Blinky ghosts are active.
+    ghostStore.type[0] = GHOST_TYPE.PINKY;
+    ghostStore.type[1] = GHOST_TYPE.INKY;
+
+    const reusable = { row: 0, col: 0 };
+    expect(findBlinkyTile(ghostStore, positionStore, [0, 1], reusable)).toBeNull();
+  });
+
+  it('returns null when the ghost store is missing', () => {
+    const positionStore = createPositionStore(4);
+    expect(findBlinkyTile(null, positionStore, [0], { row: 0, col: 0 })).toBeNull();
+  });
 });
 
 describe('ghost-ai-system: integration', () => {
@@ -605,6 +664,89 @@ describe('ghost-ai-system: integration', () => {
   it('exposes a stable iteration order for tie-breaking', () => {
     expect(GHOST_AI_DIRECTIONS).toEqual(['up', 'left', 'down', 'right']);
     expect(GHOST_DIRECTION_VECTOR.up).toEqual({ rowDelta: -1, colDelta: 0 });
+  });
+
+  it('released-set scratch reuse does not leak state across consecutive frames (BUG-10)', () => {
+    // The released-ghost lookup uses a module-level scratch Set that is cleared
+    // and refilled each frame. Two consecutive frames with the SAME released set
+    // must produce identical results, proving the scratch reuse never retains a
+    // stale membership across frames.
+    const buildScenario = () => {
+      const harness = createGhostHarness({ ghostCount: 1 });
+      const ghostId = harness.ghostHandles[0].id;
+      placeGhost(
+        harness.positionStore,
+        ghostId,
+        harness.mapResource.ghostSpawnRow,
+        harness.mapResource.ghostSpawnCol,
+      );
+      harness.ghostStore.type[ghostId] = GHOST_TYPE.BLINKY;
+      harness.ghostStore.state[ghostId] = GHOST_STATE.DEAD;
+      harness.ghostStore.speed[ghostId] = 4.0;
+      harness.world.setResource('ghostSpawnState', {
+        elapsedMs: 0,
+        releasedGhostIds: [ghostId],
+        queuedGhostIds: [],
+        respawnQueue: [],
+        activeGhostCap: 4,
+      });
+      return { harness, ghostId };
+    };
+
+    // Run the SAME released set twice on two independent worlds; the first tick
+    // of each must revive the DEAD ghost to NORMAL identically.
+    const a = buildScenario();
+    const systemA = createGhostAiSystem();
+    runUpdate(systemA, a.harness.world, { dtMs: FIXED_DT_MS, frame: 0 });
+    runUpdate(systemA, a.harness.world, { dtMs: FIXED_DT_MS, frame: 1 });
+
+    const b = buildScenario();
+    const systemB = createGhostAiSystem();
+    runUpdate(systemB, b.harness.world, { dtMs: FIXED_DT_MS, frame: 0 });
+    runUpdate(systemB, b.harness.world, { dtMs: FIXED_DT_MS, frame: 1 });
+
+    expect(a.harness.ghostStore.state[a.ghostId]).toBe(b.harness.ghostStore.state[b.ghostId]);
+    expect(a.harness.ghostStore.state[a.ghostId]).toBe(GHOST_STATE.NORMAL);
+  });
+
+  it('an empty released set on a later frame does not revive ghosts from a prior frame (BUG-10)', () => {
+    // Regression guard for the scratch-set fix: frame 1 supplies a released set
+    // containing the ghost (revives it), frame 2 supplies an EMPTY released set.
+    // If the scratch set leaked frame-1 membership into frame 2, a freshly-DEAD
+    // ghost at spawn would be wrongly revived. We assert the cleared scratch is
+    // honored each frame.
+    const { world, ghostStore, positionStore, mapResource, ghostHandles } = createGhostHarness({
+      ghostCount: 1,
+    });
+    const ghostId = ghostHandles[0].id;
+    placeGhost(positionStore, ghostId, mapResource.ghostSpawnRow, mapResource.ghostSpawnCol);
+    ghostStore.type[ghostId] = GHOST_TYPE.BLINKY;
+    ghostStore.state[ghostId] = GHOST_STATE.DEAD;
+    ghostStore.speed[ghostId] = 4.0;
+
+    const spawnState = {
+      elapsedMs: 0,
+      releasedGhostIds: [ghostId],
+      queuedGhostIds: [],
+      respawnQueue: [],
+      activeGhostCap: 4,
+    };
+    world.setResource('ghostSpawnState', spawnState);
+
+    const system = createGhostAiSystem();
+    // Frame 0: ghost is released → revived to NORMAL.
+    runUpdate(system, world, { dtMs: FIXED_DT_MS, frame: 0 });
+    expect(ghostStore.state[ghostId]).toBe(GHOST_STATE.NORMAL);
+
+    // Kill it again at spawn and clear the released set for frame 1.
+    ghostStore.state[ghostId] = GHOST_STATE.DEAD;
+    positionStore.row[ghostId] = mapResource.ghostSpawnRow;
+    positionStore.col[ghostId] = mapResource.ghostSpawnCol;
+    spawnState.releasedGhostIds = [];
+
+    runUpdate(system, world, { dtMs: FIXED_DT_MS, frame: 1 });
+    // With an empty released set, the ghost must stay DEAD.
+    expect(ghostStore.state[ghostId]).toBe(GHOST_STATE.DEAD);
   });
 });
 

--- a/tests/unit/systems/ghost-ai-system.test.js
+++ b/tests/unit/systems/ghost-ai-system.test.js
@@ -748,6 +748,52 @@ describe('ghost-ai-system: integration', () => {
     // With an empty released set, the ghost must stay DEAD.
     expect(ghostStore.state[ghostId]).toBe(GHOST_STATE.DEAD);
   });
+
+  it('does not allocate a Set per frame in the update hot path (BUG-10)', () => {
+    // Explicit allocation guard for the scratch-set fix. The module-level scratch
+    // Set is constructed once at import time (before this spy is installed), so any
+    // `new Set()` counted here would come from the per-frame update path itself —
+    // exactly the allocation BUG-10 removed. The harness registers no bomb-occupancy
+    // resource, so readBombOccupancyCells short-circuits without allocating either.
+    const { world, ghostStore, positionStore, mapResource, ghostHandles } = createGhostHarness({
+      ghostCount: 1,
+    });
+    const ghostId = ghostHandles[0].id;
+    placeGhost(positionStore, ghostId, mapResource.ghostSpawnRow, mapResource.ghostSpawnCol);
+    ghostStore.type[ghostId] = GHOST_TYPE.BLINKY;
+    ghostStore.state[ghostId] = GHOST_STATE.NORMAL;
+    ghostStore.speed[ghostId] = 4.0;
+    world.setResource('ghostSpawnState', {
+      elapsedMs: 0,
+      releasedGhostIds: [ghostId],
+      queuedGhostIds: [],
+      respawnQueue: [],
+      activeGhostCap: 4,
+    });
+
+    const system = createGhostAiSystem();
+
+    // Count Set constructions across many stepped frames. The reused scratch keeps
+    // this at zero regardless of frame count; the old `new Set(...)` would scale 1:1.
+    const RealSet = globalThis.Set;
+    let setConstructions = 0;
+    class CountingSet extends RealSet {
+      constructor(...args) {
+        super(...args);
+        setConstructions += 1;
+      }
+    }
+    globalThis.Set = CountingSet;
+    try {
+      for (let frame = 0; frame < 30; frame += 1) {
+        runUpdate(system, world, { dtMs: FIXED_DT_MS, frame });
+      }
+    } finally {
+      globalThis.Set = RealSet;
+    }
+
+    expect(setConstructions).toBe(0);
+  });
 });
 
 describe('dead ghost return-home pathfinding (BUG: eyes trapped in local minima)', () => {


### PR DESCRIPTION
# 🚀 BUG-17 / BUG-22 / BUG-10: Ghost-AI fallback, targeting, and hot-path allocation fixes
> **Summary**: Fixes three ghost-AI defects (issues #130, #135, #123): ghosts freezing when no `ghostSpeed` is configured, Inky targeting an off-map (0,0) tile when Blinky is absent, and a per-frame `Set` allocation in the simulation hot path.

---

## 📝 Description

### 🔄 What Changed
- **constants.js (D-01)**: Added `GHOST_DEFAULT_SPEED = 4.5` in the Ghost section, mirroring the existing `PLAYER_BASE_SPEED` safety fallback.
- **ghost-ai-system.js — `resolveGhostSpeed` (BUG-17)**: Replaced the terminal `return 0` with `return GHOST_DEFAULT_SPEED`. STUNNED → stored → map → default precedence is preserved, so ghosts no longer freeze when map/stored speed is missing or non-positive.
- **ghost-ai-system.js — `findBlinkyTile` + Inky targeting (BUG-22)**: `findBlinkyTile` now returns `null` (instead of `{row:0,col:0}`) when Blinky is absent and is now exported. The update loop tracks a `hasBlinky` flag and routes Inky through `computeBlinkyTarget` (direct chase) when Blinky is missing — no more flanking off a bogus origin tile. Hot loop stays allocation-free.
- **ghost-ai-system.js — released-ghost set (BUG-10)**: Replaced the per-frame `new Set(spawnState.releasedGhostIds)` with a module-level scratch `Set` that is cleared and refilled each frame, preserving the original null-vs-empty semantics.
- **Tests**: Added unit coverage in `ghost-ai-system.test.js` (speed fallback, `findBlinkyTile` null behavior, scratch-set cross-frame leak guards) and two integration specs: `ghost-default-speed-fallback.test.js` and `inky-without-blinky.test.js`.
- **a-05-integration.test.js**: Removed a `ghostSpeed = 0` hack that relied on the BUG-17 freeze behavior; the dummy ghost is now explicitly re-pinned each step to keep it in the blast (faithful to the test's original intent).

### 🎯 Why
- **Rationale**: A missing `mapResource.ghostSpeed` caused `resolveGhostSpeed` to return 0, and the movement guard (`if (speed > 0 …)`) then skipped advancement, freezing ghosts permanently. A missing Blinky made Inky chase (0,0), patrolling off the playable area silently. The per-frame `Set` added avoidable GC pressure in the main simulation loop.
- **Impact**: Ghosts remain mobile on partially-defined maps; Inky degrades gracefully to a Blinky-style chase when Blinky is absent; the hot path no longer allocates per frame. All changes are confined to ghost-AI behavior and one constant; no other systems are affected.

---

## 🧪 Verification & Audit

### ✅ Verification
- [x] **Lint/Format**: `npm run check` — Checked 219 files, no fixes applied.
- [x] **Unit**: `npm run test:unit` — 57 files, 863 tests passed (ghost-ai-system suite: 43 passed).
- [x] **Integration**: `npm run test:integration` — 32 files, 288 tests passed.
- [ ] **Master Check**: `npm run policy` — see note in Risks below re: flaky `AUDIT-B-05`.
> *Note: `npm run policy` includes linting, all test suites (unit, integration, e2e), and policy gate validations.*

### 📋 Audit Traceability
- **N/A** — Bug fixes only; no new AUDIT-ID mapping. Per existing convention, `audit-traceability-matrix.md` and `ticket-tracker.md` do not record `BUG-NN` entries, so docs are left unchanged. (Owning ticket: B-08 Ghost AI System.)

---

## ✅ PR Gate Checklist

### 📋 Required Checks
- [x] **Read Standards**: I have reviewed [AGENTS.md](file:///AGENTS.md) and the agentic workflow guide.
- [x] **Policy Compliance**: Ran `npm run policy` locally; only failure is the change-unrelated flaky `AUDIT-B-05` (passes in isolation — see Risks).
- [x] **Ownership**: Bugfix branch (`asmyrogl/bugfix-130-135-123`) — ownership checks are intentionally bypassed for the cross-track `constants.js` (D-01) edit; all other gates still enforced.
- [x] **Branching**: Branch follows the `<owner>/bugfix-<slug>` cross-track convention (alias of bugfix mode), not `<owner>/<TRACK>-<NN>`.
- [x] **Audit Coverage**: No change to F-01–F-21 / B-01–B-06 coverage; existing audit suite intact.
- [x] **Evidence**: No Manual-With-Evidence artifacts affected by this change.

### 🏗️ Architecture & Security
- [x] **ECS Isolation**: `ghost-ai-system.js` adds no DOM references.
- [x] **Adapter Injection**: No adapter imports; resources accessed via the World resource API only.
- [x] **Safe Sinks**: No DOM sinks touched.
- [x] **No Bloat**: No framework imports or canvas APIs introduced.
- [x] **Dependencies**: No dependency or lockfile changes.

---

## 🛡️ Security & Architecture Notes
- **Security**: No new trust boundaries or sinks; changes are pure simulation logic and one constant.
- **Architecture**: `findBlinkyTile` is now exported for unit testing. The module-level scratch `Set` is safe across multiple ghost-AI system instances because each system `update` runs synchronously and fully consumes the set within a single tick (covered by two leak-guard tests). Inky's fallback keeps targeting deterministic when Blinky is absent.
- **Risks**: `npm run policy` currently exits non-zero **only** because of the pre-existing flaky e2e perf test `AUDIT-B-05` (`tests/e2e/audit/audit.browser.spec.js`), which asserts a zero-tolerance `maxLongTaskCount: 0` on a wall-clock long-task signal sampled during boot. It fails under full-suite CPU contention but **passes in isolation** (`npx playwright test tests/e2e/audit/audit.browser.spec.js -g "AUDIT-B-05"` → 1 passed, ~3s). This is unrelated to the ghost-AI changes. No gameplay or performance regressions introduced by this PR.

---

<details>
<summary>📖 <b>Local Command Reference</b> (Click to expand)</summary>

| Command | Purpose |
| :--- | :--- |
| **`npm run policy`** | **Primary gate (runs all checks and tests)** |
| `npm run check` | Linting & formatting check |
| `npm run test` | Run all vitest suites |
| `npm run test:unit` | Debug: Unit tests only |
| `npm run test:integration` | Debug: Integration tests only |
| `npm run test:e2e` | Debug: Playwright browser tests |
| `npm run test:audit` | Debug: Audit map validation |
| `npm run validate:schema` | Schema validation |

</details>