### PR TITLE
Medvall/bugfix coverage 275 285

### DIFF
--- a/docs/pr-messages/bugfix-coverage-275-285-pr.md
+++ b/docs/pr-messages/bugfix-coverage-275-285-pr.md
@@ -1,0 +1,61 @@
+# 🔧 bugfix: missing-coverage remediation — #275 (CI-11) + #285 (CI-13)
+
+> Two AGENTS.md "MUST" coverage gaps assigned to @edvallm, bundled on one `bugfix-*` branch (bypasses ownership — `main.ecs.js` is Track A and #275 spans D/C). #275 hardens + tests `prefers-reduced-motion`; #285 adds the dev-mode DOM budget assertion.
+
+## Required checks
+
+- [x] I read AGENTS.md and the agentic workflow guide.
+- [x] I ran `npm run policy` locally.
+- [x] Branch name follows `<owner>/bugfix-<slug>` (`medvall/bugfix-coverage-275-285`) — bugfix branch, ownership bypass.
+- [x] Changes are within scope; cross-track files (`main.ecs.js`) carried under the bugfix bypass.
+- [x] Ran unit + e2e for the touched paths.
+- [x] Checked security sinks, architecture boundaries, dependency impact (none).
+- [x] Requested human review.
+
+## Layer boundary confirmations
+
+- [x] `src/ecs/systems/` unchanged (no DOM added).
+- [x] `assertDomElementBudget` is an app-boundary guard in `main.ecs.js` (the composition root), not an ECS system; it only reads `document.querySelectorAll` and throws — no simulation coupling.
+- [x] Untrusted UI content still uses safe sinks; the budget breach is surfaced via the existing `renderCriticalError` `textContent` path (no HTML injection).
+- [x] No framework imports or canvas APIs introduced.
+
+## What changed
+
+### #275 (CI-11) — `prefers-reduced-motion` hardening + test
+- **`styles/animations.css`**: added a universal reduced-motion safety net inside the existing `@media (prefers-reduced-motion: reduce)` block — `*, *::before, *::after { animation-duration/transition-duration/*-delay: 0s !important }`.
+- **`tests/e2e/reduced-motion.spec.js`** (new): emulates `reducedMotion: 'reduce'`, then asserts (a) no element in the `#overlay-root` menu subtree declares a non-zero animation/transition, and (b) no element site-wide declares a non-zero transition (during gameplay + boot).
+
+### #285 (CI-13) — dev-mode DOM budget assertion
+- **`src/main.ecs.js`**: added `DOM_ELEMENT_BUDGET = 500` and `assertDomElementBudget({ documentRef, limit })`, which throws a descriptive error when `document.querySelectorAll('*').length` exceeds the budget. Wired a `isDevelopment()`-gated call right after `runtime.start()` (initial board is in the DOM); the breach throws and is surfaced by the existing startup `catch` → `renderCriticalError`.
+- **`tests/unit/main.ecs.test.js`**: 4 new cases (budget constant, boundary = 500 passes, 501 throws a visible descriptive error, custom limit).
+
+## Why
+
+- AGENTS.md §Accessibility (MUST): non-gameplay motion must respect `prefers-reduced-motion`. AGENTS.md §Performance budget (MUST): "DOM ≤ 500 total after level load. Assert in dev-mode startup." The reduced-motion rule was checked nowhere in tests; the DOM budget was checked only in e2e, never asserted in the app itself.
+
+## Tests
+
+- `npx vitest run` — **1298 passed** (incl. 4 new `assertDomElementBudget` cases).
+- `npx playwright test tests/e2e/reduced-motion.spec.js` — **2 passed**.
+- `npm run check` — clean. `npm run policy` — green modulo the pre-existing e2e timing-flake cluster (documented in prior PRs; unrelated to this change).
+
+**TDD note (honest):**
+- **#285** followed failing-test-first: the new unit tests failed (function absent) → implemented → pass.
+- **#275** did **not** reproduce as a failure — the per-animation handling in `animations.css` already existed and the new e2e passed against unmodified code. Rather than fabricate a failure, this PR **locks in** the contract with the (passing) regression test and **hardens** it with the universal override so compliance no longer depends on incidental quirks (an unused `.overlay` transition; a malformed `.overlay__btn` transition-duration) or on every future selector being hand-added to the block.
+
+## Audit questions affected
+
+- **F-19/F-20/F-21** (paint/layers/promotion) — unaffected; reduced-motion only zeroes durations. **F-17/F-18** (frame budget) — the DOM budget guard is dev-only, no production/runtime cost.
+- Accessibility (reduced-motion) and the DOM-budget performance MUST now have explicit automated coverage.
+
+## Security notes
+
+- No new sinks. Budget breach message is plain `textContent` via `renderCriticalError`. No untrusted input; the count comes from the live DOM.
+
+## Architecture / dependency notes
+
+- `assertDomElementBudget` lives at the app composition root, not in an ECS system; dev-gated so production startup is unchanged. No dependency or lockfile changes.
+
+## Risks
+
+- Low. The reduced-motion override is additive and scoped to the reduce media query. The DOM assertion runs only under `isDevelopment()` and only throws on a genuine >500 breach (surfaced, not silent) — production builds are unaffected.

--- a/src/main.ecs.js
+++ b/src/main.ecs.js
@@ -271,6 +271,37 @@ async function loadAudioClipManifest({ fetchImpl, logger = console } = {}) {
   return result;
 }
 
+/**
+ * AGENTS.md performance budget: "DOM Elements ≤ 500 total after level load.
+ * Assert in dev-mode startup." Transient rendering uses fixed object pools, so
+ * an over-budget count signals a pool leak or an unpooled per-frame element.
+ */
+export const DOM_ELEMENT_BUDGET = 500;
+
+/**
+ * Dev-mode DOM budget guard. Counts live elements and throws a descriptive
+ * error when the count exceeds the budget so an over-budget load fails loudly
+ * during local development. Callers gate this behind `isDevelopment()`; the
+ * startup try/catch routes the throw through `renderCriticalError`, making the
+ * failure visible (not just a silent console line).
+ *
+ * @param {{ documentRef?: Document, limit?: number }} [options]
+ * @returns {number} The observed element count (when within budget).
+ */
+export function assertDomElementBudget({
+  documentRef = typeof document !== 'undefined' ? document : null,
+  limit = DOM_ELEMENT_BUDGET,
+} = {}) {
+  const count = documentRef?.querySelectorAll?.('*')?.length ?? 0;
+  if (count > limit) {
+    throw new Error(
+      `DOM element budget exceeded: ${count} elements after level load (limit ${limit}). ` +
+        'Transient rendering must use fixed object pools (AGENTS.md performance budget).',
+    );
+  }
+  return count;
+}
+
 export function renderCriticalError(overlayRoot, error) {
   if (!overlayRoot) {
     return;
@@ -821,6 +852,14 @@ export async function bootstrapApplication({
     });
 
     runtime.start();
+
+    // #285 / CI-13: the initial level's board is in the DOM by now, so assert
+    // the AGENTS.md DOM budget in development. A breach throws and is surfaced
+    // by the catch below (renderCriticalError), catching pool leaks locally.
+    if (isDevelopment()) {
+      assertDomElementBudget({ documentRef: targetDocument });
+    }
+
     return runtime;
   } catch (error) {
     if (inputAdapter && typeof inputAdapter.destroy === 'function') {

--- a/styles/animations.css
+++ b/styles/animations.css
@@ -195,19 +195,20 @@
 /** Disable non-gameplay animations when user prefers reduced motion. */
 @media (prefers-reduced-motion: reduce) {
   /**
-   * Universal safety net (AGENTS.md MUST): neutralize every animation and
-   * transition so compliance never depends on a specific selector being kept
-   * in sync below, nor on incidental quirks (e.g. an unused `.overlay`
-   * transition or a malformed transition-duration). The targeted rules that
-   * follow still provide simplified *static* appearances (opacity/shadow tints).
+   * Zero out all animation/transition durations via the custom properties
+   * that every animation declaration references. This cascades naturally
+   * without needing !important — the specific animation :none rules below
+   * still provide simplified static appearances.
    */
-  *,
-  *::before,
-  *::after {
-    animation-duration: 0s !important;
-    animation-delay: 0s !important;
-    transition-duration: 0s !important;
-    transition-delay: 0s !important;
+  :root {
+    --anim-walk-duration: 0s;
+    --anim-bomb-fuse-duration: 0s;
+    --anim-fire-duration: 0s;
+    --anim-stun-flash-duration: 0s;
+    --anim-invincible-blink-duration: 0s;
+    --anim-speed-trail-duration: 0s;
+    --anim-menu-transition-duration: 0s;
+    --anim-overlay-fade-duration: 0s;
   }
 
   /** Pellet pulse: disable pulsing, keep static appearance. */

--- a/styles/animations.css
+++ b/styles/animations.css
@@ -194,6 +194,22 @@
 
 /** Disable non-gameplay animations when user prefers reduced motion. */
 @media (prefers-reduced-motion: reduce) {
+  /**
+   * Universal safety net (AGENTS.md MUST): neutralize every animation and
+   * transition so compliance never depends on a specific selector being kept
+   * in sync below, nor on incidental quirks (e.g. an unused `.overlay`
+   * transition or a malformed transition-duration). The targeted rules that
+   * follow still provide simplified *static* appearances (opacity/shadow tints).
+   */
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0s !important;
+    animation-delay: 0s !important;
+    transition-duration: 0s !important;
+    transition-delay: 0s !important;
+  }
+
   /** Pellet pulse: disable pulsing, keep static appearance. */
   .collectible--power-pellet {
     animation: none;

--- a/tests/e2e/reduced-motion.spec.js
+++ b/tests/e2e/reduced-motion.spec.js
@@ -1,0 +1,68 @@
+/**
+ * E2E: prefers-reduced-motion compliance (#275 / CI-11).
+ *
+ * AGENTS.md (MUST): non-gameplay motion — menus, overlays, transitions, and
+ * decorative effects — must be disabled or simplified when
+ * `prefers-reduced-motion: reduce` is active.
+ *
+ * This asserts the contract end-to-end: under emulated reduced motion, no
+ * element in the overlay/menu subtree may declare a non-zero animation or
+ * transition duration, and the same holds site-wide for transitions.
+ */
+
+import { expect, test } from '@playwright/test';
+import { bootRuntime, startGameAndWait } from './helpers/game-helpers.js';
+
+// Serialized in the page: returns the worst (largest) animation/transition
+// duration found under `root`, with a human-readable offender label.
+function scanMotion(rootSelector) {
+  const durs = (value) =>
+    Math.max(0, ...String(value).split(',').map((v) => Number.parseFloat(v) || 0));
+  const label = (el) =>
+    el.tagName.toLowerCase() +
+    (typeof el.className === 'string' && el.className ? `.${el.className.trim().split(/\s+/).join('.')}` : '');
+
+  const root = rootSelector ? document.querySelector(rootSelector) : document;
+  const els = root ? root.querySelectorAll('*') : [];
+  let maxAnimation = 0;
+  let maxTransition = 0;
+  let animationOffender = '(none)';
+  let transitionOffender = '(none)';
+
+  for (const el of els) {
+    const cs = getComputedStyle(el);
+    const animation = cs.animationName === 'none' ? 0 : durs(cs.animationDuration);
+    const transition = durs(cs.transitionDuration);
+    if (animation > maxAnimation) {
+      maxAnimation = animation;
+      animationOffender = `${label(el)} (${cs.animationName})`;
+    }
+    if (transition > maxTransition) {
+      maxTransition = transition;
+      transitionOffender = label(el);
+    }
+  }
+  return { maxAnimation, maxTransition, animationOffender, transitionOffender };
+}
+
+test('overlays/menus honor prefers-reduced-motion (no animation or transition)', async ({
+  page,
+}) => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  await bootRuntime(page); // boots into MENU with the Start overlay shown
+
+  await expect(page.locator('[data-screen="start"]')).toHaveCount(1);
+
+  const menu = await page.evaluate(scanMotion, '#overlay-root');
+  expect(menu.maxAnimation, `animating overlay element: ${menu.animationOffender}`).toBe(0);
+  expect(menu.maxTransition, `transitioning overlay element: ${menu.transitionOffender}`).toBe(0);
+});
+
+test('no element declares a non-zero transition under prefers-reduced-motion', async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  await bootRuntime(page);
+  await startGameAndWait(page, { levelIndex: 0 });
+
+  const site = await page.evaluate(scanMotion, null);
+  expect(site.maxTransition, `transitioning element: ${site.transitionOffender}`).toBe(0);
+});

--- a/tests/e2e/reduced-motion.spec.js
+++ b/tests/e2e/reduced-motion.spec.js
@@ -17,10 +17,17 @@ import { bootRuntime, startGameAndWait } from './helpers/game-helpers.js';
 // duration found under `root`, with a human-readable offender label.
 function scanMotion(rootSelector) {
   const durs = (value) =>
-    Math.max(0, ...String(value).split(',').map((v) => Number.parseFloat(v) || 0));
+    Math.max(
+      0,
+      ...String(value)
+        .split(',')
+        .map((v) => Number.parseFloat(v) || 0),
+    );
   const label = (el) =>
     el.tagName.toLowerCase() +
-    (typeof el.className === 'string' && el.className ? `.${el.className.trim().split(/\s+/).join('.')}` : '');
+    (typeof el.className === 'string' && el.className
+      ? `.${el.className.trim().split(/\s+/).join('.')}`
+      : '');
 
   const root = rootSelector ? document.querySelector(rootSelector) : document;
   const els = root ? root.querySelectorAll('*') : [];

--- a/tests/unit/main.ecs.test.js
+++ b/tests/unit/main.ecs.test.js
@@ -3,8 +3,10 @@ import { enqueue } from '../../src/ecs/resources/event-queue.js';
 import { GAME_STATE } from '../../src/ecs/resources/game-status.js';
 import { createBootstrap } from '../../src/game/bootstrap.js';
 import {
+  assertDomElementBudget,
   bootstrapApplication,
   createGameRuntime,
+  DOM_ELEMENT_BUDGET,
   installUnhandledRejectionHandler,
   renderCriticalError,
 } from '../../src/main.ecs.js';
@@ -605,5 +607,34 @@ describe('main.ecs.js', () => {
         runtime?.stop();
       }
     });
+  });
+});
+
+describe('assertDomElementBudget (#285 / CI-13)', () => {
+  const makeDoc = (count) => ({
+    querySelectorAll: vi.fn((selector) => {
+      expect(selector).toBe('*');
+      return { length: count };
+    }),
+  });
+
+  it('exposes the AGENTS.md DOM budget of 500', () => {
+    expect(DOM_ELEMENT_BUDGET).toBe(500);
+  });
+
+  it('returns the element count when within budget (boundary: exactly 500)', () => {
+    expect(assertDomElementBudget({ documentRef: makeDoc(500) })).toBe(500);
+  });
+
+  it('throws a visible, descriptive error when the count exceeds the budget', () => {
+    expect(() => assertDomElementBudget({ documentRef: makeDoc(501) })).toThrow(
+      /DOM element budget exceeded: 501 .*\(limit 500\)/,
+    );
+  });
+
+  it('honors a custom limit', () => {
+    expect(() => assertDomElementBudget({ documentRef: makeDoc(11), limit: 10 })).toThrow(
+      /budget exceeded/,
+    );
   });
 });


### PR DESCRIPTION
# 🔧 bugfix: missing-coverage remediation — #275 (CI-11) + #285 (CI-13)

> Two AGENTS.md "MUST" coverage gaps assigned to @edvallm, bundled on one `bugfix-*` branch (bypasses ownership — `main.ecs.js` is Track A and #275 spans D/C). #275 hardens + tests `prefers-reduced-motion`; #285 adds the dev-mode DOM budget assertion.

## Required checks

- [x] I read AGENTS.md and the agentic workflow guide.
- [x] I ran `npm run policy` locally.
- [x] Branch name follows `<owner>/bugfix-<slug>` (`medvall/bugfix-coverage-275-285`) — bugfix branch, ownership bypass.
- [x] Changes are within scope; cross-track files (`main.ecs.js`) carried under the bugfix bypass.
- [x] Ran unit + e2e for the touched paths.
- [x] Checked security sinks, architecture boundaries, dependency impact (none).
- [x] Requested human review.

## Layer boundary confirmations

- [x] `src/ecs/systems/` unchanged (no DOM added).
- [x] `assertDomElementBudget` is an app-boundary guard in `main.ecs.js` (the composition root), not an ECS system; it only reads `document.querySelectorAll` and throws — no simulation coupling.
- [x] Untrusted UI content still uses safe sinks; the budget breach is surfaced via the existing `renderCriticalError` `textContent` path (no HTML injection).
- [x] No framework imports or canvas APIs introduced.

## What changed

### #275 (CI-11) — `prefers-reduced-motion` hardening + test
- **`styles/animations.css`**: added a universal reduced-motion safety net inside the existing `@media (prefers-reduced-motion: reduce)` block — `*, *::before, *::after { animation-duration/transition-duration/*-delay: 0s !important }`.
- **`tests/e2e/reduced-motion.spec.js`** (new): emulates `reducedMotion: 'reduce'`, then asserts (a) no element in the `#overlay-root` menu subtree declares a non-zero animation/transition, and (b) no element site-wide declares a non-zero transition (during gameplay + boot).

### #285 (CI-13) — dev-mode DOM budget assertion
- **`src/main.ecs.js`**: added `DOM_ELEMENT_BUDGET = 500` and `assertDomElementBudget({ documentRef, limit })`, which throws a descriptive error when `document.querySelectorAll('*').length` exceeds the budget. Wired a `isDevelopment()`-gated call right after `runtime.start()` (initial board is in the DOM); the breach throws and is surfaced by the existing startup `catch` → `renderCriticalError`.
- **`tests/unit/main.ecs.test.js`**: 4 new cases (budget constant, boundary = 500 passes, 501 throws a visible descriptive error, custom limit).

## Why

- AGENTS.md §Accessibility (MUST): non-gameplay motion must respect `prefers-reduced-motion`. AGENTS.md §Performance budget (MUST): "DOM ≤ 500 total after level load. Assert in dev-mode startup." The reduced-motion rule was checked nowhere in tests; the DOM budget was checked only in e2e, never asserted in the app itself.

## Tests

- `npx vitest run` — **1298 passed** (incl. 4 new `assertDomElementBudget` cases).
- `npx playwright test tests/e2e/reduced-motion.spec.js` — **2 passed**.
- `npm run check` — clean. `npm run policy` — green modulo the pre-existing e2e timing-flake cluster (documented in prior PRs; unrelated to this change).

**TDD note (honest):**
- **#285** followed failing-test-first: the new unit tests failed (function absent) → implemented → pass.
- **#275** did **not** reproduce as a failure — the per-animation handling in `animations.css` already existed and the new e2e passed against unmodified code. Rather than fabricate a failure, this PR **locks in** the contract with the (passing) regression test and **hardens** it with the universal override so compliance no longer depends on incidental quirks (an unused `.overlay` transition; a malformed `.overlay__btn` transition-duration) or on every future selector being hand-added to the block.

## Audit questions affected

- **F-19/F-20/F-21** (paint/layers/promotion) — unaffected; reduced-motion only zeroes durations. **F-17/F-18** (frame budget) — the DOM budget guard is dev-only, no production/runtime cost.
- Accessibility (reduced-motion) and the DOM-budget performance MUST now have explicit automated coverage.

## Security notes

- No new sinks. Budget breach message is plain `textContent` via `renderCriticalError`. No untrusted input; the count comes from the live DOM.

## Architecture / dependency notes

- `assertDomElementBudget` lives at the app composition root, not in an ECS system; dev-gated so production startup is unchanged. No dependency or lockfile changes.

## Risks

- Low. The reduced-motion override is additive and scoped to the reduce media query. The DOM assertion runs only under `isDevelopment()` and only throws on a genuine >500 breach (surfaced, not silent) — production builds are unaffected.
