### PR TITLE
fix: resolve 4 low-severity Track C bugs (#240, #241, #246, #248)

### DIFF
--- a/src/ecs/systems/ghost-ai-system.js
+++ b/src/ecs/systems/ghost-ai-system.js
@@ -71,7 +71,6 @@ const DEFAULT_BOMB_OCCUPANCY_RESOURCE_KEY = 'bombCellOccupancy';
 const DEFAULT_SPAWN_RESOURCE_KEY = 'ghostSpawnState';
 const DEFAULT_RNG_RESOURCE_KEY = 'rng';
 
-const MAX_DELTA_MS = 1000;
 const MOVEMENT_EPSILON = 1e-9;
 
 /**
@@ -557,7 +556,7 @@ function readDeltaMs(context) {
     return 0;
   }
 
-  return Math.min(deltaMs, MAX_DELTA_MS);
+  return deltaMs;
 }
 
 function readBombOccupancyCells(resource, mapResource) {

--- a/src/ecs/systems/life-system.js
+++ b/src/ecs/systems/life-system.js
@@ -47,7 +47,6 @@ const DEFAULT_PLAYER_LIFE_RESOURCE_KEY = 'playerLife';
 const DEFAULT_POSITION_RESOURCE_KEY = 'position';
 const DEFAULT_RESPAWN_INTENT_RESOURCE_KEY = 'respawnIntent';
 const DEFAULT_VELOCITY_RESOURCE_KEY = 'velocity';
-const MAX_DELTA_MS = 1000;
 
 function createDefaultPlayerLife() {
   return {
@@ -87,7 +86,7 @@ function getDeltaMs(context) {
     return 0;
   }
 
-  return Math.min(deltaMs, MAX_DELTA_MS);
+  return deltaMs;
 }
 
 function tickInvincibility(playerLife, deltaMs) {
@@ -166,10 +165,11 @@ function respawnPlayerEntity(world, resources, playerLife) {
     if (playerStore.isSpeedBoosted) {
       playerStore.isSpeedBoosted[entityId] = 0;
     }
-    if (playerStore.invincibilityMs) {
-      playerStore.invincibilityMs[entityId] = playerLife.invincibilityRemainingMs;
-    }
   }
+
+  // Route through the same sync helper the per-frame tick uses, instead of a
+  // second independent store write, so the two never have a chance to drift.
+  syncPlayerInvincibility(playerStore, playerEntity, playerLife);
 }
 
 function triggerGameOver(gameStatus) {

--- a/src/ecs/systems/power-up-system.js
+++ b/src/ecs/systems/power-up-system.js
@@ -46,7 +46,6 @@ const DEFAULT_PLAYER_RESOURCE_KEY = 'player';
 const DEFAULT_PLAYER_ENTITY_RESOURCE_KEY = 'playerEntity';
 const DEFAULT_POWER_UP_STATE_RESOURCE_KEY = 'powerUpState';
 const DEFAULT_EVENT_QUEUE_RESOURCE_KEY = 'eventQueue';
-const MAX_DELTA_MS = 1000;
 
 /**
  * Canonical collision intent type for individual power-up pickups.
@@ -118,7 +117,7 @@ function readDeltaMs(context) {
     return 0;
   }
 
-  return Math.min(deltaMs, MAX_DELTA_MS);
+  return deltaMs;
 }
 
 function readFrameIndex(context) {

--- a/src/ecs/systems/scoring-system.js
+++ b/src/ecs/systems/scoring-system.js
@@ -85,7 +85,7 @@ export function computeLevelClearBonus(remainingSeconds) {
   const safeRemainingSeconds =
     Number.isFinite(remainingSeconds) && remainingSeconds > 0 ? remainingSeconds : 0;
 
-  return SCORE_LEVEL_CLEAR + safeRemainingSeconds * SCORE_TIME_BONUS_MULTIPLIER;
+  return SCORE_LEVEL_CLEAR + Math.floor(safeRemainingSeconds) * SCORE_TIME_BONUS_MULTIPLIER;
 }
 
 /**

--- a/src/ecs/systems/timer-system.js
+++ b/src/ecs/systems/timer-system.js
@@ -35,7 +35,6 @@ const DEFAULT_EVENT_QUEUE_RESOURCE_KEY = 'eventQueue';
 const DEFAULT_GAME_STATUS_RESOURCE_KEY = 'gameStatus';
 const DEFAULT_LEVEL_LOADER_RESOURCE_KEY = 'levelLoader';
 const DEFAULT_TIMER_RESOURCE_KEY = 'levelTimer';
-const MAX_DELTA_MS = 1000;
 
 export function getLevelDurationSeconds(level) {
   const levelIndex = Math.floor(level) - 1;
@@ -103,7 +102,7 @@ function getDeltaSeconds(context) {
     return 0;
   }
 
-  return Math.min(deltaMs, MAX_DELTA_MS) / 1000;
+  return deltaMs / 1000;
 }
 
 function expireTimer(gameStatus, timerState, handleGameOver) {
@@ -169,11 +168,11 @@ export function createTimerSystem(options = {}) {
         );
       };
 
-      if (expireIfNeeded(gameStatus, timerState, handleGameOver)) {
+      if (gameStatus?.currentState !== GAME_STATE.PLAYING) {
         return;
       }
 
-      if (gameStatus?.currentState !== GAME_STATE.PLAYING) {
+      if (expireIfNeeded(gameStatus, timerState, handleGameOver)) {
         return;
       }
 

--- a/tests/integration/gameplay/bug-17-respawn-invincibility-sync.test.js
+++ b/tests/integration/gameplay/bug-17-respawn-invincibility-sync.test.js
@@ -1,0 +1,173 @@
+/**
+ * Integration test: player respawn invincibility must be visible to
+ * collision-system within the same frame it is granted, not one frame later.
+ *
+ * collision-system runs before life-system in the logic phase (bootstrap.js),
+ * and reads `playerStore.invincibilityMs` to decide hazard damage. This test
+ * places fire directly on the spawn tile, kills the player, and steps several
+ * frames to confirm the respawned player never takes fatal fire damage from
+ * the hazard it respawns onto.
+ *
+ * Note: this passes both before and after the fix that consolidated the two
+ * independent invincibility-store writers into one (life-system.js), since
+ * both writers happened to agree on this exact scenario — it guards the
+ * invariant going forward rather than reproducing a live bug.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { createGhostStore, createPlayerStore } from '../../../src/ecs/components/actors.js';
+import { COMPONENT_MASK } from '../../../src/ecs/components/registry.js';
+import {
+  COLLIDER_TYPE,
+  createColliderStore,
+  createPositionStore,
+} from '../../../src/ecs/components/spatial.js';
+import { createHealthStore } from '../../../src/ecs/components/stats.js';
+import { FIXED_DT_MS } from '../../../src/ecs/resources/constants.js';
+import { createEventQueue } from '../../../src/ecs/resources/event-queue.js';
+import { createGameStatus, GAME_STATE } from '../../../src/ecs/resources/game-status.js';
+import { createMapResource } from '../../../src/ecs/resources/map-resource.js';
+import {
+  COLLISION_ENTITY_REQUIRED_MASK,
+  createCollisionSystem,
+} from '../../../src/ecs/systems/collision-system.js';
+import { createLifeSystem } from '../../../src/ecs/systems/life-system.js';
+import { World } from '../../../src/ecs/world/world.js';
+
+function createRespawnHazardRawMap() {
+  return {
+    level: 106,
+    metadata: {
+      activeGhostTypes: [0],
+      ghostSpeed: 4,
+      maxGhosts: 1,
+      name: 'BUG-17 Respawn Hazard Harness',
+      timerSeconds: 120,
+    },
+    dimensions: { rows: 5, columns: 5 },
+    grid: [
+      [1, 1, 1, 1, 1],
+      [1, 0, 0, 0, 1],
+      [1, 0, 6, 0, 1],
+      [1, 0, 5, 0, 1],
+      [1, 1, 1, 1, 1],
+    ],
+    spawn: {
+      ghostHouse: { bottomRow: 3, leftCol: 2, rightCol: 2, topRow: 3 },
+      ghostSpawnPoint: { row: 3, col: 2 },
+      player: { row: 2, col: 2 },
+    },
+  };
+}
+
+function placeEntity(positionStore, entityId, row, col) {
+  positionStore.prevRow[entityId] = row;
+  positionStore.prevCol[entityId] = col;
+  positionStore.row[entityId] = row;
+  positionStore.col[entityId] = col;
+  positionStore.targetRow[entityId] = row;
+  positionStore.targetCol[entityId] = col;
+}
+
+function addCollisionEntity(world, positionStore, colliderStore, colliderType, row, col) {
+  const entity = world.createEntity(COLLISION_ENTITY_REQUIRED_MASK);
+  colliderStore.type[entity.id] = colliderType;
+  placeEntity(positionStore, entity.id, row, col);
+  return entity;
+}
+
+describe('BUG-17 respawn invincibility cross-step sync', () => {
+  it('does not immediately kill the player again when fire sits on the respawn tile', () => {
+    const world = new World();
+    const mapResource = createMapResource(createRespawnHazardRawMap());
+    const maxEntities = 8;
+    const positionStore = createPositionStore(maxEntities);
+    const colliderStore = createColliderStore(maxEntities);
+    const playerStore = createPlayerStore(maxEntities);
+    const ghostStore = createGhostStore(maxEntities);
+    const healthStore = createHealthStore(maxEntities);
+    const eventQueue = createEventQueue();
+    const collisionIntents = [];
+
+    const player = world.createEntity(COLLISION_ENTITY_REQUIRED_MASK | COMPONENT_MASK.PLAYER);
+    colliderStore.type[player.id] = COLLIDER_TYPE.PLAYER;
+    placeEntity(positionStore, player.id, mapResource.playerSpawnRow, mapResource.playerSpawnCol);
+
+    const playerLife = {
+      lives: 3,
+      isInvincible: false,
+      invincibilityRemainingMs: 0,
+    };
+    const gameStatus = createGameStatus(GAME_STATE.PLAYING);
+
+    world.setResource('mapResource', mapResource);
+    world.setResource('position', positionStore);
+    world.setResource('collider', colliderStore);
+    world.setResource('player', playerStore);
+    world.setResource('ghost', ghostStore);
+    world.setResource('health', healthStore);
+    world.setResource('collisionIntents', collisionIntents);
+    world.setResource('eventQueue', eventQueue);
+    world.setResource('playerLife', playerLife);
+    world.setResource('gameStatus', gameStatus);
+    world.setResource('playerEntity', player);
+
+    // Bootstrap wiring registers collision-system before life-system in the
+    // logic phase (src/game/bootstrap.js ~L378, ~L394) — match that order
+    // exactly so this test reflects real runtime scheduling.
+    world.registerSystem(createCollisionSystem());
+    world.registerSystem(createLifeSystem());
+
+    // A fire entity sits directly on the player's spawn tile so that, once
+    // the player dies and is respawned onto that same tile, the very next
+    // collision pass will see the player and the fire sharing a cell.
+    addCollisionEntity(
+      world,
+      positionStore,
+      colliderStore,
+      COLLIDER_TYPE.FIRE,
+      mapResource.playerSpawnRow,
+      mapResource.playerSpawnCol,
+    );
+
+    // Frame 1: a ghost also shares the player's tile this frame, so
+    // collision-system emits a player-death intent that life-system consumes,
+    // decrementing lives and respawning the player back onto the spawn tile
+    // (which the fire entity still occupies).
+    const ghost = addCollisionEntity(
+      world,
+      positionStore,
+      colliderStore,
+      COLLIDER_TYPE.GHOST,
+      mapResource.playerSpawnRow,
+      mapResource.playerSpawnCol,
+    );
+
+    world.runFixedStep({ dtMs: FIXED_DT_MS });
+
+    expect(playerLife.lives).toBe(2);
+    expect(playerLife.isInvincible).toBe(true);
+
+    // The store read by collision-system must reflect the just-granted
+    // invincibility within the SAME frame respawn happened, not one frame
+    // later. This is the exact cross-step sync guarantee BUG-17 is about:
+    // playerStore.invincibilityMs must never lag behind playerLife.
+    expect(playerStore.invincibilityMs[player.id]).toBe(playerLife.invincibilityRemainingMs);
+
+    // Move the ghost away so only the fire remains on the spawn tile for
+    // subsequent frames — isolating the fire/invincibility interaction.
+    placeEntity(positionStore, ghost.id, 1, 1);
+
+    // Step a few more frames while the player sits on the spawn tile with
+    // fire present. If invincibility sync lags by a frame relative to
+    // collision-system's read, the player will take fatal fire damage here
+    // and lose a second life immediately after respawning.
+    for (let i = 0; i < 3; i += 1) {
+      world.runFixedStep({ dtMs: FIXED_DT_MS });
+    }
+
+    expect(playerLife.lives).toBe(2);
+    expect(collisionIntents.some((intent) => intent.type === 'player-death')).toBe(false);
+  });
+});

--- a/tests/integration/gameplay/bug-21-fixed-step-delta.test.js
+++ b/tests/integration/gameplay/bug-21-fixed-step-delta.test.js
@@ -1,0 +1,75 @@
+/**
+ * Integration test: every logic-phase system receives exactly `FIXED_DT_MS`
+ * as `context.dtMs` on each simulation step, regardless of real-world frame
+ * timing (irregular `stepFrame` call gaps, multi-step catch-up frames).
+ *
+ * This is the guarantee that makes the per-system `Math.min(dtMs, MAX_DELTA_MS)`
+ * clamps in timer-system.js, power-up-system.js, ghost-ai-system.js, and
+ * life-system.js dead code: `dtMs` can never exceed `FIXED_DT_MS` in the real
+ * game loop, so the clamp can never activate.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { FIXED_DT_MS } from '../../../src/ecs/resources/constants.js';
+import { createMapResource } from '../../../src/ecs/resources/map-resource.js';
+import { createBootstrap } from '../../../src/game/bootstrap.js';
+
+function createProbeMapResource() {
+  return createMapResource({
+    level: 1,
+    metadata: {
+      name: 'BUG-21 Fixed Step Harness',
+      timerSeconds: 120,
+      maxGhosts: 1,
+      ghostSpeed: 4.0,
+      activeGhostTypes: [0],
+    },
+    dimensions: { rows: 5, columns: 5 },
+    grid: [
+      [1, 1, 1, 1, 1],
+      [1, 3, 3, 3, 1],
+      [1, 3, 6, 3, 1],
+      [1, 3, 5, 3, 1],
+      [1, 1, 1, 1, 1],
+    ],
+    spawn: {
+      player: { row: 1, col: 1 },
+      ghostHouse: { topRow: 3, bottomRow: 3, leftCol: 2, rightCol: 2 },
+      ghostSpawnPoint: { row: 3, col: 2 },
+    },
+  });
+}
+
+describe('BUG-21 fixed-step delta invariant', () => {
+  it('always passes FIXED_DT_MS to logic-phase systems, even across irregular real-time frame gaps', () => {
+    const bootstrap = createBootstrap({
+      loadMapForLevel: () => createProbeMapResource(),
+      now: 0,
+    });
+    bootstrap.gameFlow.startGame();
+
+    const observedDeltas = [];
+    bootstrap.world.registerSystem({
+      name: 'bug-21-dtms-probe',
+      phase: 'logic',
+      resourceCapabilities: { read: [], write: [] },
+      update(context) {
+        observedDeltas.push(context.dtMs);
+      },
+    });
+
+    // Irregular real-time gaps, including a large spike that would previously
+    // have produced multiple catch-up steps and/or exercised the MAX_DELTA_MS
+    // clamp if dtMs itself scaled with wall-clock time.
+    const frameTimestamps = [0, 16, 33, 500, 516, 5000, 5017];
+    for (const timestamp of frameTimestamps) {
+      bootstrap.stepFrame(timestamp);
+    }
+
+    expect(observedDeltas.length).toBeGreaterThan(0);
+    for (const dtMs of observedDeltas) {
+      expect(dtMs).toBe(FIXED_DT_MS);
+    }
+  });
+});

--- a/tests/integration/gameplay/c-01-level-clear-bonus.test.js
+++ b/tests/integration/gameplay/c-01-level-clear-bonus.test.js
@@ -77,6 +77,19 @@ describe('C-01 level-clear scoring runtime integration', () => {
     expect(expectedBonus).toBe(1000 + 73 * 10);
   });
 
+  it('awards a bonus matching the HUD-displayed (floored) seconds, not the raw float', () => {
+    const world = buildWorld({ remainingSeconds: 47.8 });
+    const scoringSystem = createScoringSystem();
+    const levelProgressSystem = createLevelProgressSystem();
+
+    stepLogic({ scoringSystem, levelProgressSystem, world, frame: 0 });
+    stepLogic({ scoringSystem, levelProgressSystem, world, frame: 1 });
+
+    // HUD displays Math.floor(47.8) = 47 seconds, so the bonus must be based
+    // on the same floored value: 1000 + 47 * 10 = 1470 (not 1000 + 478 = 1478).
+    expect(world.getResource('scoreState').totalPoints).toBe(1000 + 47 * 10);
+  });
+
   it('does not double-award across additional frames in LEVEL_COMPLETE', () => {
     const world = buildWorld({ remainingSeconds: 30 });
     const scoringSystem = createScoringSystem();

--- a/tests/unit/systems/life-system.test.js
+++ b/tests/unit/systems/life-system.test.js
@@ -400,7 +400,7 @@ describe('life-system', () => {
     });
   });
 
-  it('caps large dtMs spikes while counting down invincibility', () => {
+  it('applies large dtMs spikes without clamping, since the fixed-step loop never produces them', () => {
     const world = new World();
     const lifeSystem = createLifeSystem();
 
@@ -417,8 +417,8 @@ describe('life-system', () => {
 
     expect(world.getResource('playerLife')).toEqual({
       lives: 2,
-      isInvincible: true,
-      invincibilityRemainingMs: 500,
+      isInvincible: false,
+      invincibilityRemainingMs: 0,
     });
   });
 

--- a/tests/unit/systems/power-up-system.test.js
+++ b/tests/unit/systems/power-up-system.test.js
@@ -247,18 +247,19 @@ describe('power-up-system', () => {
     expect(playerStore.speedBoostMs[playerEntity.id]).toBe(400);
   });
 
-  it('clamps spike deltas above the safety ceiling instead of underflowing timers', () => {
+  it('applies large deltas without clamping, expiring the stun outright', () => {
     const { ghostEntities, ghostStore, world } = setupHarness({ ghostCount: 1 });
     ghostStore.state[ghostEntities[0].id] = GHOST_STATE.STUNNED;
     ghostStore.timerMs[ghostEntities[0].id] = STUN_MS;
 
     const system = createPowerUpSystem();
-    // A 60s spike (e.g. tab throttling) is clamped to the safety ceiling so
-    // the timer drains predictably instead of underflowing in a single tick.
+    // The fixed-step loop never produces deltas this large, but a delta that
+    // exceeds the remaining stun duration should expire it immediately rather
+    // than being clamped to a smaller, arbitrary per-tick ceiling.
     runUpdate(system, world, { dtMs: 60_000, frame: 0 });
 
-    expect(ghostStore.state[ghostEntities[0].id]).toBe(GHOST_STATE.STUNNED);
-    expect(ghostStore.timerMs[ghostEntities[0].id]).toBe(STUN_MS - 1000);
+    expect(ghostStore.state[ghostEntities[0].id]).toBe(GHOST_STATE.NORMAL);
+    expect(ghostStore.timerMs[ghostEntities[0].id]).toBe(0);
   });
 
   it('does not refresh the HUD stun window when no ghosts were eligible', () => {

--- a/tests/unit/systems/scoring-system.test.js
+++ b/tests/unit/systems/scoring-system.test.js
@@ -76,7 +76,7 @@ describe('scoring-system', () => {
 
   it('computes the canonical level-clear bonus as a pure helper', () => {
     expect(computeLevelClearBonus(0)).toBe(1000);
-    expect(computeLevelClearBonus(12.5)).toBe(1125);
+    expect(computeLevelClearBonus(12.5)).toBe(1120);
     expect(computeLevelClearBonus(-3)).toBe(1000);
   });
 

--- a/tests/unit/systems/timer-system.test.js
+++ b/tests/unit/systems/timer-system.test.js
@@ -138,6 +138,27 @@ describe('timer-system', () => {
     expect(gameStatus.previousState).toBe(GAME_STATE.PLAYING);
   });
 
+  it('does not attempt a transition or emit events when expired while not playing', () => {
+    const world = new World();
+    const timerSystem = createTimerSystem();
+    const gameStatus = createGameStatus(GAME_STATE.PAUSED);
+
+    world.setResource('clock', createClock(0));
+    world.setResource('gameStatus', gameStatus);
+    world.setResource('eventQueue', []);
+    world.setResource('levelLoader', createLevelLoaderStub(0));
+    world.setResource('levelTimer', {
+      activeLevel: 1,
+      durationSeconds: 120,
+      remainingSeconds: 0,
+    });
+
+    updateTimer(timerSystem, world);
+
+    expect(gameStatus.currentState).toBe(GAME_STATE.PAUSED);
+    expect(world.getResource('eventQueue')).toEqual([]);
+  });
+
   it('transitions immediately if timer is already zero before update', () => {
     const world = new World();
     const timerSystem = createTimerSystem();
@@ -157,7 +178,7 @@ describe('timer-system', () => {
     expect(gameStatus.currentState).toBe(GAME_STATE.GAME_OVER);
   });
 
-  it('caps delta time to avoid large jumps (lag spike)', () => {
+  it('applies large deltas without clamping, since the fixed-step loop never produces them', () => {
     const world = new World();
     const timerSystem = createTimerSystem();
 
@@ -172,7 +193,7 @@ describe('timer-system', () => {
 
     updateTimer(timerSystem, world, 5000);
 
-    expect(world.getResource('levelTimer').remainingSeconds).toBe(9);
+    expect(world.getResource('levelTimer').remainingSeconds).toBe(5);
   });
 
   it('ignores negative dtMs values', () => {


### PR DESCRIPTION
# 🚀 Resolve 4 low-severity Track C bugs
> **Summary**: Fixes four LOW-severity issues (#240, #241, #246, #248), grouped together since each is a small, self-contained fix under `src/ecs/systems/`.

---

## 📝 Description

### 🔄 What Changed
- **timer-system**: Moved the `GAME_STATE.PLAYING` check to the top of `update()`, before timer-expiry logic runs (#240).
- **scoring-system**: `computeLevelClearBonus` now floors `remainingSeconds` before multiplying by the time-bonus rate, matching the HUD's rounded-down display (#241).
- **life-system**: `respawnPlayerEntity` no longer writes `playerStore.invincibilityMs` independently — it now routes through the same `syncPlayerInvincibility` helper the per-frame tick uses, removing a second drift-prone write site (#246).
- **timer-system / life-system / ghost-ai-system / power-up-system**: Removed the dead `Math.min(dtMs, MAX_DELTA_MS)` clamp from all four, since the fixed-step loop guarantees `dtMs` is always `FIXED_DT_MS` (#248).

### 🎯 Why
- **#240**: `expireIfNeeded()` ran before the `PLAYING` guard, so expiry validation executed redundantly on menu/paused frames, and would misbehave if `VALID_TRANSITIONS` ever allowed `GAME_OVER` from a non-`PLAYING` state.
- **#241**: The bonus paid out on the raw float while the HUD showed the floored value — a visible mismatch between what the player saw and what they were paid (e.g. 47.8s remaining displayed "0:47" but paid for 47.8).
- **#246**: Two independent writers for the same derived value (`playerStore.invincibilityMs`) happened to agree today but could silently desync if either call site changed later — exactly the kind of fragile cross-step sync ordering the issue called out.
- **#248**: The clamp could never activate in the real game loop and masked what should be an impossible variable-step scenario, per the issue's own framing ("dead clamping code that masks potential variable-step drift bugs").
- **Impact**: All four changes are localized to `src/ecs/systems/*` and their tests; no gameplay-facing behavior changes except the #241 scoring correction (which fixes a display/payout mismatch, not a balance change).

---

## 🧪 Verification & Audit

### ✅ Verification
- [x] **Master Check**: `npm run policy` — passes except `npm run test:e2e`, which fails with `ENOSPC: System limit for number of file watchers reached`. Independently confirmed as a pre-existing local-machine environment limitation (inotify instance exhaustion from concurrently running editor/agent processes), not caused by this branch — reproduces identically on unmodified `main`. `npx vitest run` (98 files / 1298 tests) passes with zero failures; `policy:checks`, `policy:forbidden`, `policy:header`, and `policy:trace` all pass individually.

### 📋 Audit Traceability
- N/A — this is an ad hoc GitHub-issue bugfix branch (`bugfix-*` convention), not a tracked `C-NN` ticket with `AUDIT-XX` entries. Underlying findings are recorded in `docs/audit-reports/phase-3/audit-report-2026-06-27.md` (BUG-05↔#248, BUG-06↔#241, BUG-16↔#246).

---

## ✅ PR Gate Checklist

### 📋 Required Checks
- [x] **Read Standards**: Reviewed `AGENTS.md` and the agentic workflow guide.
- [x] **Policy Compliance**: Ran `npm run policy` locally; all checks pass except the pre-existing environmental `test:e2e` ENOSPC failure (see Verification above).
- [x] **Ownership**: Two of the five changed files (`power-up-system.js`, `ghost-ai-system.js`) are Track B, not Track C — intentionally covered by this branch's `bugfix-*` naming, which bypasses per-track ownership scoping for cross-track bugfix work.
- [x] **Branching**: Uses the repo's documented `bugfix-*` convention (`BUGFIX_BRANCH_PATTERN`) instead of `<owner>/<TRACK>-<NN>`, since this branch bundles 4 separate GitHub issues rather than one `C-NN` feature ticket.
- [ ] **Audit Coverage**: Not applicable — no F-01–F-21/B-01–B-06 items are affected by this branch.
- [ ] **Evidence**: Not applicable — no F-19/F-20/F-21/B-06 manual evidence required for this scope.

### 🏗️ Architecture & Security
- [x] **ECS Isolation**: No DOM references added to any modified `src/ecs/systems/` file.
- [x] **Adapter Injection**: No adapter access added or changed.
- [x] **Safe Sinks**: No new DOM sinks touched.
- [x] **No Bloat**: No framework or canvas API imports introduced.
- [x] **Dependencies**: No dependency or lockfile changes.

---

## 🛡️ Security & Architecture Notes
- **Security**: No new trust boundaries or sinks — grepped the full diff for `var `, `require(`, `eval(`, `innerHTML`; zero matches.
- **Architecture**: The #248 fix relies on `bootstrap.js`'s `stepFrame()` always passing `dtMs: fixedDtMs` into `world.runFixedStep`, and `clock.js`'s `tickClock()` never deriving `dtMs` from wall-clock time directly — verified by reading both files directly, not just asserted.
- **Risks**: #246 and #248's new integration tests pass both before and after their fixes, since both issues describe structural fragility/dead code rather than an active bug — documented in each test's header comment as a regression guard rather than a live-bug repro.