### PR TITLE
fix: resolve last-pellet timer race and add quick-toggle tests (#231, #280)

### DIFF
--- a/src/game/bootstrap.js
+++ b/src/game/bootstrap.js
@@ -389,6 +389,11 @@ function createDefaultSystemsByPhase(options = {}) {
         playerEntityResourceKey,
         playerResourceKey,
       }),
+      // BUG-09: level-progress-system must run before timer-system so a
+      // last-pellet clear and a timer expiry on the same step resolve to
+      // LEVEL_COMPLETE/VICTORY rather than timer-system winning the race and
+      // transitioning to GAME_OVER first.
+      createLevelProgressSystem({ eventQueueResourceKey, mapResourceKey }),
       createTimerSystem({ eventQueueResourceKey }),
       createScoringSystem(),
       createLifeSystem({
@@ -400,7 +405,6 @@ function createDefaultSystemsByPhase(options = {}) {
         positionResourceKey,
         velocityResourceKey,
       }),
-      createLevelProgressSystem({ eventQueueResourceKey, mapResourceKey }),
       createSpawnSystem(),
       // The release-bridge must run after createSpawnSystem so it observes the
       // freshly updated releasedGhostIds list before the next physics phase.

--- a/tests/integration/adapters/screens-audio-toggle.test.js
+++ b/tests/integration/adapters/screens-audio-toggle.test.js
@@ -1,0 +1,242 @@
+/**
+ * CI-12 dedicated integration tests for the persistent audio quick-toggle
+ * DOM adapter (C-11B), covering rendering, click toggling, state updates,
+ * and ARIA updates in isolation from the Settings overlay suite.
+ *
+ * Uses the same small purpose-built fake DOM as the other adapter suites
+ * (no jsdom dependency): querySelector/querySelectorAll by attribute,
+ * get/setAttribute, addEventListener + dispatch.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { createAudioQuickToggle } from '../../../src/adapters/dom/screens-audio-toggle.js';
+
+// ---- minimal DOM ----------------------------------------------------------
+
+function createElement(tag, attrs = {}) {
+  const attributes = new Map(Object.entries(attrs));
+  const children = [];
+  const listeners = new Map();
+
+  function dispatch(target, type, extra = {}) {
+    const handlers = listeners.get(type);
+    if (!handlers) {
+      return;
+    }
+    const event = { type, currentTarget: target, target, ...extra };
+    for (const handler of handlers) {
+      handler(event);
+    }
+  }
+
+  const el = {
+    tagName: tag.toUpperCase(),
+    children,
+    get textContent() {
+      return attributes.get('__text') ?? '';
+    },
+    set textContent(v) {
+      attributes.set('__text', String(v));
+    },
+    getAttribute: (n) => (attributes.has(n) ? attributes.get(n) : null),
+    setAttribute: (n, v) => attributes.set(n, String(v)),
+    removeAttribute: (n) => attributes.delete(n),
+    addEventListener(type, handler) {
+      if (!listeners.has(type)) listeners.set(type, new Set());
+      listeners.get(type).add(handler);
+    },
+    removeEventListener(type, handler) {
+      listeners.get(type)?.delete(handler);
+    },
+    click() {
+      dispatch(this, 'click', { currentTarget: this });
+    },
+    append(...nodes) {
+      children.push(...nodes);
+    },
+    querySelector(selector) {
+      const match = /\[([\w-]+)(?:="([^"]*)")?\]/.exec(selector);
+      if (!match) {
+        return null;
+      }
+      const [, attrName, attrValue] = match;
+      return (
+        children.find((child) => {
+          const value = child.getAttribute(attrName);
+          return attrValue === undefined ? value !== null : value === attrValue;
+        }) ?? null
+      );
+    },
+    querySelectorAll(selector) {
+      const match = /\[([\w-]+)(?:="([^"]*)")?\]/.exec(selector);
+      if (!match) {
+        return [];
+      }
+      const [, attrName, attrValue] = match;
+      return children.filter((child) => {
+        const value = child.getAttribute(attrName);
+        return attrValue === undefined ? value !== null : value === attrValue;
+      });
+    },
+  };
+  return el;
+}
+
+function buildToggleRoot(overrides = {}) {
+  const root = createElement('div');
+  const music = createElement('button', {
+    'data-audio-toggle': 'musicEnabled',
+    'data-icon-on': '🎵',
+    'data-icon-off': '🔇',
+    'aria-pressed': 'true',
+    ...overrides.music,
+  });
+  const musicIcon = createElement('span', { 'data-audio-toggle-icon': '' });
+  musicIcon.textContent = '🎵';
+  music.append(musicIcon);
+
+  const sfx = createElement('button', {
+    'data-audio-toggle': 'sfxEnabled',
+    'data-icon-on': '🔊',
+    'data-icon-off': '🔇',
+    'aria-pressed': 'true',
+    ...overrides.sfx,
+  });
+  const sfxIcon = createElement('span', { 'data-audio-toggle-icon': '' });
+  sfxIcon.textContent = '🔊';
+  sfx.append(sfxIcon);
+
+  root.append(music, sfx);
+  return { root, music, sfx };
+}
+
+describe('screens-audio-toggle (CI-12 dedicated coverage)', () => {
+  it('renders both quick-toggle buttons discoverable by [data-audio-toggle]', () => {
+    const { root } = buildToggleRoot();
+    createAudioQuickToggle(root, {});
+
+    const buttons = root.querySelectorAll('[data-audio-toggle]');
+    expect(buttons).toHaveLength(2);
+    expect(buttons.map((b) => b.getAttribute('data-audio-toggle'))).toEqual([
+      'musicEnabled',
+      'sfxEnabled',
+    ]);
+  });
+
+  it('flips aria-pressed and the icon, and reports the new state, on click', () => {
+    const { root, music } = buildToggleRoot();
+    const onToggle = vi.fn();
+    createAudioQuickToggle(root, { onToggle });
+
+    music.click();
+
+    expect(music.getAttribute('aria-pressed')).toBe('false');
+    expect(music.querySelector('[data-audio-toggle-icon]').textContent).toBe('🔇');
+    expect(onToggle).toHaveBeenCalledWith('musicEnabled', false);
+  });
+
+  it('toggles back on with the correct aria-pressed and icon on a second click', () => {
+    const { root, sfx } = buildToggleRoot();
+    const onToggle = vi.fn();
+    createAudioQuickToggle(root, { onToggle });
+
+    sfx.click();
+    sfx.click();
+
+    expect(sfx.getAttribute('aria-pressed')).toBe('true');
+    expect(sfx.querySelector('[data-audio-toggle-icon]').textContent).toBe('🔊');
+    expect(onToggle).toHaveBeenNthCalledWith(2, 'sfxEnabled', true);
+  });
+
+  it('toggles music and sfx independently of one another', () => {
+    const { root, music, sfx } = buildToggleRoot();
+    const onToggle = vi.fn();
+    createAudioQuickToggle(root, { onToggle });
+
+    music.click();
+
+    expect(music.getAttribute('aria-pressed')).toBe('false');
+    expect(sfx.getAttribute('aria-pressed')).toBe('true');
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('seeds button state from initialSettings without firing onToggle', () => {
+    const { root, music, sfx } = buildToggleRoot();
+    const onToggle = vi.fn();
+    createAudioQuickToggle(root, {
+      onToggle,
+      initialSettings: { musicEnabled: false, sfxEnabled: true },
+    });
+
+    expect(music.getAttribute('aria-pressed')).toBe('false');
+    expect(music.querySelector('[data-audio-toggle-icon]').textContent).toBe('🔇');
+    expect(sfx.getAttribute('aria-pressed')).toBe('true');
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it("sync() reflects externally changed settings using each button's own icons", () => {
+    const { root, music, sfx } = buildToggleRoot();
+    const toggle = createAudioQuickToggle(root, {});
+
+    toggle.sync({ musicEnabled: false, sfxEnabled: true });
+
+    expect(music.getAttribute('aria-pressed')).toBe('false');
+    expect(music.querySelector('[data-audio-toggle-icon]').textContent).toBe('🔇');
+    expect(sfx.getAttribute('aria-pressed')).toBe('true');
+    expect(sfx.querySelector('[data-audio-toggle-icon]').textContent).toBe('🔊');
+  });
+
+  it('sync() with a partial/missing settings object does not throw or change untouched keys', () => {
+    const { root, music, sfx } = buildToggleRoot();
+    const toggle = createAudioQuickToggle(root, {});
+
+    expect(() => toggle.sync(undefined)).not.toThrow();
+    expect(() => toggle.sync({})).not.toThrow();
+    expect(music.getAttribute('aria-pressed')).toBe('true');
+    expect(sfx.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('destroy() detaches click listeners so further clicks are inert', () => {
+    const { root, music } = buildToggleRoot();
+    const onToggle = vi.fn();
+    const toggle = createAudioQuickToggle(root, { onToggle });
+
+    toggle.destroy();
+    music.click();
+
+    expect(onToggle).not.toHaveBeenCalled();
+    expect(music.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('falls back to the shared speaker icons when a button has no data-icon-on/off', () => {
+    const root = createElement('div');
+    const plain = createElement('button', {
+      'data-audio-toggle': 'musicEnabled',
+      'aria-pressed': 'true',
+    });
+    const icon = createElement('span', { 'data-audio-toggle-icon': '' });
+    icon.textContent = '🔊';
+    plain.append(icon);
+    root.append(plain);
+
+    createAudioQuickToggle(root, {});
+    plain.click();
+
+    expect(icon.textContent).toBe('🔇');
+    plain.click();
+    expect(icon.textContent).toBe('🔊');
+  });
+
+  it('tolerates a missing root without throwing, and returns a no-op controller', () => {
+    expect(() => createAudioQuickToggle(null, {})).not.toThrow();
+    const noop = createAudioQuickToggle(null, {});
+    expect(() => noop.sync({ musicEnabled: false })).not.toThrow();
+    expect(() => noop.destroy()).not.toThrow();
+  });
+
+  it('tolerates a root with no matching toggle buttons without throwing', () => {
+    const root = createElement('div');
+    expect(() => createAudioQuickToggle(root, {})).not.toThrow();
+  });
+});

--- a/tests/integration/adapters/screens-settings.test.js
+++ b/tests/integration/adapters/screens-settings.test.js
@@ -1,6 +1,6 @@
 /**
  * C-11B integration tests for the Settings overlay behavior of the Track C
- * screens adapter, plus the persistent audio quick-toggle adapter.
+ * screens adapter.
  *
  * Uses a small purpose-built fake DOM (no jsdom dependency, runs in the node
  * environment like the other adapter suites) that faithfully models the exact
@@ -15,13 +15,14 @@
  * - accessibility: aria-pressed toggles, aria-valuenow sliders
  * - onSettingChange forwards booleans (toggles) and 0..1 volumes (sliders)
  * - initialSettings + syncSettingsControls reflect persisted state
- * - quick-toggle adapter: aria-pressed + emoji icon + onToggle callback
+ *
+ * The persistent audio quick-toggle adapter has its own dedicated suite:
+ * tests/integration/adapters/screens-audio-toggle.test.js (CI-12).
  */
 
 import { describe, expect, it, vi } from 'vitest';
 
 import { createScreensAdapter } from '../../../src/adapters/dom/screens-adapter.js';
-import { createAudioQuickToggle } from '../../../src/adapters/dom/screens-audio-toggle.js';
 
 // ---- minimal DOM ----------------------------------------------------------
 
@@ -568,102 +569,5 @@ describe('screens-adapter: onConfirm cue fires for every confirmed button', () =
     keydown(root, 'ArrowDown'); // index 1 = music volume slider
     keydown(root, 'ArrowRight'); // adjust slider — not a confirm
     expect(onConfirm).not.toHaveBeenCalledWith('settings-volume-music');
-  });
-});
-
-describe('screens-audio-toggle: persistent quick-toggle (C-11B)', () => {
-  function buildToggleRoot(initial = { musicEnabled: true, sfxEnabled: true }) {
-    const root = createElement('div');
-    const music = createElement('button', {
-      'data-audio-toggle': 'musicEnabled',
-      'data-icon-on': '🎵',
-      'data-icon-off': '🔇',
-      'aria-pressed': 'true',
-    });
-    music.append(
-      (() => {
-        const i = createElement('span', { 'data-audio-toggle-icon': '' });
-        i.textContent = '🎵';
-        return i;
-      })(),
-    );
-    const sfx = createElement('button', {
-      'data-audio-toggle': 'sfxEnabled',
-      'data-icon-on': '🔊',
-      'data-icon-off': '🔇',
-      'aria-pressed': 'true',
-    });
-    sfx.append(
-      (() => {
-        const i = createElement('span', { 'data-audio-toggle-icon': '' });
-        i.textContent = '🔊';
-        return i;
-      })(),
-    );
-    root.append(music, sfx);
-    return { root, music, sfx, initial };
-  }
-
-  it('flips aria-pressed + emoji and reports the new state on click', () => {
-    const { root, music } = buildToggleRoot();
-    const onToggle = vi.fn();
-    createAudioQuickToggle(root, { onToggle });
-
-    music.click();
-
-    expect(music.getAttribute('aria-pressed')).toBe('false');
-    expect(music.querySelector('[data-audio-toggle-icon]').textContent).toBe('🔇');
-    expect(onToggle).toHaveBeenCalledWith('musicEnabled', false);
-  });
-
-  it('seeds button state from initialSettings without firing onToggle', () => {
-    const { root, music, sfx } = buildToggleRoot();
-    const onToggle = vi.fn();
-    createAudioQuickToggle(root, {
-      onToggle,
-      initialSettings: { musicEnabled: false, sfxEnabled: true },
-    });
-
-    expect(music.getAttribute('aria-pressed')).toBe('false');
-    expect(music.querySelector('[data-audio-toggle-icon]').textContent).toBe('🔇');
-    expect(sfx.getAttribute('aria-pressed')).toBe('true');
-    expect(onToggle).not.toHaveBeenCalled();
-  });
-
-  it("uses each button's own data-icon-on / data-icon-off (music 🎵, sfx 🔊)", () => {
-    const { root, music, sfx } = buildToggleRoot();
-    createAudioQuickToggle(root, {});
-
-    // Off then back on: each button restores its distinct enabled icon.
-    music.click();
-    expect(music.querySelector('[data-audio-toggle-icon]').textContent).toBe('🔇');
-    music.click();
-    expect(music.querySelector('[data-audio-toggle-icon]').textContent).toBe('🎵');
-
-    sfx.click();
-    expect(sfx.querySelector('[data-audio-toggle-icon]').textContent).toBe('🔇');
-    sfx.click();
-    expect(sfx.querySelector('[data-audio-toggle-icon]').textContent).toBe('🔊');
-  });
-
-  it('sync() reflects external changes; destroy() detaches listeners', () => {
-    const { root, music } = buildToggleRoot();
-    const onToggle = vi.fn();
-    const toggle = createAudioQuickToggle(root, { onToggle });
-
-    toggle.sync({ musicEnabled: false, sfxEnabled: true });
-    expect(music.getAttribute('aria-pressed')).toBe('false');
-
-    toggle.destroy();
-    music.click();
-    // No further callbacks after destroy (the click handler was removed).
-    expect(onToggle).not.toHaveBeenCalled();
-  });
-
-  it('tolerates a missing root without throwing', () => {
-    expect(() => createAudioQuickToggle(null, {})).not.toThrow();
-    const noop = createAudioQuickToggle(null, {});
-    expect(() => noop.sync({ musicEnabled: false })).not.toThrow();
-    expect(() => noop.destroy()).not.toThrow();
   });
 });

--- a/tests/integration/gameplay/bug-09-last-pellet-timer-race.test.js
+++ b/tests/integration/gameplay/bug-09-last-pellet-timer-race.test.js
@@ -1,0 +1,64 @@
+/**
+ * Integration test: eating the last pellet on the same fixed step the level
+ * timer expires must result in LEVEL_COMPLETE (or VICTORY), not GAME_OVER.
+ *
+ * level-progress-system now runs before timer-system in the logic phase
+ * (bootstrap.js), so a last-pellet clear wins the race: the PLAYING ->
+ * LEVEL_COMPLETE transition happens before timer-system can transition
+ * PLAYING -> GAME_OVER on the same frame. This test mirrors that order
+ * directly instead of relying on bootstrap.js to catch a future regression.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { createClock } from '../../../src/ecs/resources/clock.js';
+import { createGameStatus, GAME_STATE } from '../../../src/ecs/resources/game-status.js';
+import { createLevelProgressSystem } from '../../../src/ecs/systems/level-progress-system.js';
+import { createTimerSystem } from '../../../src/ecs/systems/timer-system.js';
+import { World } from '../../../src/ecs/world/world.js';
+
+function createLevelLoaderStub(levelIndex = 0) {
+  return {
+    getCurrentLevelIndex() {
+      return levelIndex;
+    },
+  };
+}
+
+function makeClearedMap(level = 1) {
+  // Empty grid → countPellets/countPowerPellets both return 0, which is the
+  // exact signal level-progress-system uses to fire LEVEL_COMPLETE.
+  return { level, grid: [] };
+}
+
+describe('BUG-09 last-pellet-at-0:00 race', () => {
+  it('reaches LEVEL_COMPLETE (not GAME_OVER) when the last pellet is cleared the same step the timer expires', () => {
+    const world = new World();
+    // Bootstrap registers level-progress-system before timer-system in the
+    // logic phase — mirror that order exactly so this test reflects real
+    // runtime scheduling.
+    const timerSystem = createTimerSystem();
+    const levelProgressSystem = createLevelProgressSystem();
+
+    world.setResource('clock', createClock(0));
+    world.setResource('gameStatus', createGameStatus(GAME_STATE.PLAYING));
+    world.setResource('levelLoader', createLevelLoaderStub(0));
+    world.setResource('eventQueue', { events: [] });
+    // remainingSeconds already at 0: the very next step will expire it.
+    world.setResource('levelTimer', {
+      activeLevel: 1,
+      durationSeconds: 120,
+      remainingSeconds: 0,
+    });
+    // The map is already cleared (last pellet eaten this same step, prior to
+    // this logic-phase running) — this is the frame-perfect win condition.
+    world.setResource('mapResource', makeClearedMap(1));
+
+    levelProgressSystem.update({ world, dtMs: 0, frame: 0 });
+    timerSystem.update({ world, dtMs: 0, frame: 0 });
+
+    const finalState = world.getResource('gameStatus').currentState;
+    expect([GAME_STATE.LEVEL_COMPLETE, GAME_STATE.VICTORY]).toContain(finalState);
+    expect(finalState).not.toBe(GAME_STATE.GAME_OVER);
+  });
+});

--- a/tests/integration/gameplay/power-up-pickup-effect.test.js
+++ b/tests/integration/gameplay/power-up-pickup-effect.test.js
@@ -14,8 +14,8 @@ import { FIXED_DT_MS } from '../../../src/ecs/resources/constants.js';
 import { createMapResource } from '../../../src/ecs/resources/map-resource.js';
 import { createBootstrap } from '../../../src/game/bootstrap.js';
 
-// Cell types: 0 empty, 1 indestructible, 5 ghost-house, 6 player-start,
-// 7 power-up bomb, 8 power-up fire, 9 power-up speed.
+// Cell types: 0 empty, 1 indestructible, 3 pellet, 5 ghost-house,
+// 6 player-start, 7 power-up bomb, 8 power-up fire, 9 power-up speed.
 function rawMap(powerUpCell) {
   return {
     level: 1,
@@ -25,7 +25,10 @@ function rawMap(powerUpCell) {
       [1, 1, 1, 1, 1, 1, 1],
       [1, 6, powerUpCell, 0, 0, 0, 1], // player start (1,1), power-up (1,2)
       [1, 0, 0, 0, 0, 0, 1],
-      [1, 0, 0, 0, 0, 0, 1],
+      // A remaining pellet keeps the level from being trivially "cleared" by
+      // construction, so level-progress-system doesn't fire an unrelated
+      // LEVEL_COMPLETE bonus during these power-up-only assertions.
+      [1, 0, 0, 3, 0, 0, 1],
       [1, 5, 5, 5, 0, 0, 1],
       [1, 5, 5, 5, 0, 0, 1],
       [1, 1, 1, 1, 1, 1, 1],

--- a/tests/unit/game/bootstrap.test.js
+++ b/tests/unit/game/bootstrap.test.js
@@ -381,10 +381,10 @@ describe('bootstrap bomb and explosion runtime wiring', () => {
     expect(logicSystemNames).toEqual([
       'collision-system',
       'power-up-system',
+      'level-progress-system',
       'timer-system',
       'scoring-system',
       'life-system',
-      'level-progress-system',
       'spawn-system',
       'ghost-release-system',
       'ghost-animation-system',


### PR DESCRIPTION
# 🚀 Resolve last-pellet timer race and add quick-toggle tests
> **Summary**: Fixes two MEDIUM-severity issues (#231, #280), grouped together as the two solo (single-assignee) items from the same audit sweep.

---

## 📝 Description

### 🔄 What Changed
- **bootstrap**: Reordered the logic-phase system list so `level-progress-system` runs before `timer-system` (#231).
- **power-up-pickup-effect.test.js**: Added a pellet cell to the test map fixture, which previously had zero pellets and was therefore trivially "cleared" from frame one (#231, incidental fixture fix — see Risks below).
- **screens-audio-toggle**: Added `tests/integration/adapters/screens-audio-toggle.test.js`, a dedicated integration suite for the persistent audio quick-toggle adapter (#280).
- **screens-settings.test.js**: Removed the pre-existing quick-toggle coverage block that lived inside the Settings-overlay suite, now fully superseded by the new dedicated file (post-audit cleanup — see Path to PASS notes below).

### 🎯 Why
- **#231**: `timer-system` ran before `level-progress-system` in the logic phase. If the player ate the last pellet on the same fixed step the timer hit 0, `timer-system` would transition `PLAYING -> GAME_OVER` first; `level-progress-system` then saw a non-`PLAYING` state and skipped its pellet-clear check entirely, turning a frame-perfect win into a loss. Verified this reproduces on current `main` with a dedicated integration test before applying the fix.
- **#280**: The always-visible mute quick-toggle was only covered transitively inside `screens-settings.test.js` (the Settings-overlay suite), with no dedicated verification script — a regression there could obscure quick-toggle coverage.
- **Impact**: #231 changes real gameplay-facing behavior (frame-perfect level clears now win instead of losing); #280 is test-only, no production code changed.

---

## 🧪 Verification & Audit

### ✅ Verification
- [x] **Master Check**: `npm run policy` — passes except the pre-existing, environment-only `test:e2e` ENOSPC failure (inotify instance exhaustion from concurrently running editor/agent processes, reproduces identically on unmodified `main`). `npx vitest run` (98 files / 1301 tests) passes with zero failures; `policy:repo` (forbidden scan, code-quality/comment check, traceability) passes cleanly.
- [x] Wrote `tests/integration/gameplay/bug-09-last-pellet-timer-race.test.js` FIRST and confirmed it fails against the current system order (final state `GAME_OVER` instead of `LEVEL_COMPLETE`/`VICTORY`) before reordering the systems in `bootstrap.js`.
- [x] Wrote `tests/integration/adapters/screens-audio-toggle.test.js` covering rendering, independent click toggling, `initialSettings` seeding, `sync()`, `destroy()`, per-button icon fallback, and missing-root/no-match edge cases — all pass against the existing (unchanged) adapter implementation.
- [x] Ran `/pr-audit`: 3-agent multi-pass audit found no blockers. It flagged one cosmetic nit — a duplicated `it()` title between the new dedicated suite and the pre-existing quick-toggle block in `screens-settings.test.js` — which is fixed in this branch by removing the now-redundant block from `screens-settings.test.js` (full audit report kept local, not committed).

### 📋 Audit Traceability
- N/A — ad hoc GitHub-issue bugfix branch (`bugfix-*` convention), not a tracked `C-NN` ticket with `AUDIT-XX` entries.

---

## ✅ PR Gate Checklist

### 📋 Required Checks
- [x] **Read Standards**: Reviewed `AGENTS.md` and the agentic workflow guide.
- [x] **Policy Compliance**: Ran `npm run policy` locally; all checks pass except the pre-existing environmental `test:e2e` ENOSPC failure.
- [x] **Ownership**: Both changed source areas (`src/game/bootstrap.js`, `src/adapters/dom/screens-audio-toggle.js` — the latter untouched, only its test coverage added) fall under Track C.
- [x] **Branching**: Uses the repo's documented `bugfix-*` convention, bundling two independently-assigned GitHub issues (#231, #280) rather than one `C-NN` feature ticket.
- [ ] **Audit Coverage**: Not applicable — no F-01–F-21/B-01–B-06 items are affected.
- [ ] **Evidence**: Not applicable — no F-19/F-20/F-21/B-06 manual evidence required for this scope.

### 🏗️ Architecture & Security
- [x] **ECS Isolation**: No DOM references added to `src/ecs/systems/` or `src/game/bootstrap.js` beyond the existing system registration list reorder.
- [x] **Adapter Injection**: No adapter access added or changed.
- [x] **Safe Sinks**: No new DOM sinks touched; the new test file uses only a local fake-DOM harness, no real DOM APIs.
- [x] **No Bloat**: No framework or canvas API imports introduced.
- [x] **Dependencies**: No dependency or lockfile changes.

---

## 🛡️ Security & Architecture Notes
- **Security**: No new trust boundaries or sinks.
- **Architecture**: The #231 reorder only moves `level-progress-system` earlier relative to `timer-system`; `scoring-system`'s one-shot `levelClearBonusAwarded` guard (not strict same-frame/next-frame ordering) means the bonus-award timing shift this causes is safe by construction — confirmed via the full test suite.
- **Risks**: Reordering surfaced a latent fixture bug in `power-up-pickup-effect.test.js` — its map had zero pellet cells and was therefore trivially "cleared" from frame one, previously masked by the old system order. Fixed by adding one pellet cell to the fixture so the map isn't auto-cleared; the power-up assertions themselves are unchanged.
