### PR TITLE
fix: bomb-killed ghosts never respawn, resolved entirely in Track C (#228)

### DIFF
--- a/src/ecs/systems/spawn-system.js
+++ b/src/ecs/systems/spawn-system.js
@@ -28,11 +28,13 @@
  *   provides a deterministic ghost entity ordering resource.
  */
 
+import { peek } from '../resources/event-queue.js';
 import {
   GHOST_RESPAWN_MS as CANONICAL_GHOST_RESPAWN_MS,
   GHOST_SPAWN_DELAYS as CANONICAL_GHOST_SPAWN_DELAYS,
 } from '../resources/constants.js';
 import { GAME_STATE } from '../resources/game-status.js';
+import { GAMEPLAY_EVENT_TYPE } from './collision-gameplay-events.js';
 
 const FALLBACK_GHOST_SPAWN_DELAYS = Object.freeze([0, 5000, 10000, 15000]);
 const FALLBACK_GHOST_RESPAWN_MS = 5000;
@@ -44,6 +46,7 @@ const MAX_DELTA_MS = 1000;
 const DEFAULT_GAME_STATUS_RESOURCE_KEY = 'gameStatus';
 const DEFAULT_MAP_RESOURCE_KEY = 'mapResource';
 const DEFAULT_GHOST_IDS_RESOURCE_KEY = 'ghostIds';
+const DEFAULT_EVENT_QUEUE_RESOURCE_KEY = 'eventQueue';
 export const DEFAULT_DEAD_GHOST_IDS_RESOURCE_KEY = 'deadGhostIds';
 export const DEFAULT_SPAWN_RESOURCE_KEY = 'ghostSpawnState';
 
@@ -63,6 +66,17 @@ function createSpawnScratch() {
     queued: new Set(),
     released: new Set(),
     respawning: new Set(),
+    // BUG-01: highest (frame, order) GhostDefeated event already bridged into
+    // deadGhostIds, so peeking the same still-undrained event on a later tick
+    // never re-schedules a respawn for a ghost that has already returned.
+    lastSeenGhostDefeated: { frame: -1, order: -1 },
+    // Identity of the eventQueue object the watermark above was computed
+    // against. Restart replaces eventQueue with a brand new instance whose
+    // frame/order counters restart from zero (see bootstrap.js's onRestart),
+    // so a stale watermark from the previous run would reject every
+    // post-restart event as "not newer". Detecting the identity swap lets the
+    // watermark reset alongside it.
+    lastSeenEventQueue: null,
   };
 }
 
@@ -400,11 +414,83 @@ function consumeDeadGhostIds(spawnState, deadGhostIds) {
   }
 }
 
+function isNewerEventEnvelope(event, watermark) {
+  const frame = Number(event?.frame);
+  const order = Number(event?.order);
+  if (!Number.isFinite(frame) || !Number.isFinite(order)) {
+    return false;
+  }
+
+  // frame is monotonically increasing for the queue's lifetime, but order
+  // resets to 0 on every drain() — so frame must dominate the comparison, or
+  // a fresh low-order event after a drain would look "older" than a stale
+  // high-order event from before it.
+  if (frame !== watermark.frame) {
+    return frame > watermark.frame;
+  }
+
+  return order > watermark.order;
+}
+
+/**
+ * Read GhostDefeated gameplay events not yet bridged into deadGhostIds,
+ * without draining the shared queue (BUG-01).
+ *
+ * collision-system marks a fire-killed ghost DEAD and emits GhostDefeated on
+ * the shared eventQueue, but nothing wrote that ghost's id into deadGhostIds
+ * for spawn-system's respawn pipeline to pick up — the kill never scheduled a
+ * respawn. `peek()` is deliberately used instead of `drain()`: the queue's
+ * single canonical drain point is the render-phase audio-cue-system (see
+ * event-queue.js's D-01 contract), and this system runs earlier in the logic
+ * phase, so draining here would delete events other consumers still need to
+ * see this frame.
+ *
+ * Peeking alone is not enough: an event lingers in the queue until that
+ * later drain happens, so a naive peek would re-schedule the same ghost's
+ * respawn on every subsequent tick until the drain runs — including after
+ * the ghost has already come back, incorrectly resetting its respawn timer
+ * (observed as `readyAtMs` jumping forward well past `GHOST_RESPAWN_MS`).
+ * `scratch.lastSeenGhostDefeated` tracks the highest (frame, order) envelope
+ * already bridged so the same event is only ever consumed once, regardless
+ * of how many ticks pass before the shared queue is actually drained.
+ *
+ * @param {{ events: Array<{ frame: number, order: number, type: string, payload: object }> } | null | undefined} eventQueue - Shared gameplay event queue.
+ * @param {{ frame: number, order: number }} watermark - Highest (frame, order) envelope already bridged; mutated in place.
+ * @returns {number[]} Newly observed ghost entity ids from GhostDefeated events.
+ */
+function peekGhostDefeatedIds(eventQueue, watermark) {
+  if (!eventQueue) {
+    return [];
+  }
+
+  const ghostIds = [];
+  for (const event of peek(eventQueue)) {
+    if (!isNewerEventEnvelope(event, watermark)) {
+      continue;
+    }
+
+    watermark.frame = event.frame;
+    watermark.order = event.order;
+
+    if (event.type !== GAMEPLAY_EVENT_TYPE.GHOST_DEFEATED) {
+      continue;
+    }
+
+    const ghostId = Number(event.payload?.entityId);
+    if (Number.isFinite(ghostId)) {
+      ghostIds.push(Math.floor(ghostId));
+    }
+  }
+
+  return ghostIds;
+}
+
 export function createSpawnSystem(options = {}) {
   const gameStatusResourceKey = options.gameStatusResourceKey || DEFAULT_GAME_STATUS_RESOURCE_KEY;
   const ghostIdsResourceKey = options.ghostIdsResourceKey || DEFAULT_GHOST_IDS_RESOURCE_KEY;
   const deadGhostIdsResourceKey =
     options.deadGhostIdsResourceKey || DEFAULT_DEAD_GHOST_IDS_RESOURCE_KEY;
+  const eventQueueResourceKey = options.eventQueueResourceKey || DEFAULT_EVENT_QUEUE_RESOURCE_KEY;
   const mapResourceKey = options.mapResourceKey || DEFAULT_MAP_RESOURCE_KEY;
   const spawnResourceKey = options.spawnResourceKey || DEFAULT_SPAWN_RESOURCE_KEY;
 
@@ -420,11 +506,14 @@ export function createSpawnSystem(options = {}) {
         gameStatusResourceKey,
         ghostIdsResourceKey,
         deadGhostIdsResourceKey,
+        eventQueueResourceKey,
         mapResourceKey,
         spawnResourceKey,
       ],
       // `deadGhostIds` is consumed as an event queue, so the system clears it
       // after reading to avoid replaying stale death intents on later ticks.
+      // eventQueue is read-only here (peeked, never drained) — see
+      // peekGhostDefeatedIds for why.
       write: [deadGhostIdsResourceKey, spawnResourceKey],
     },
     update(context) {
@@ -432,6 +521,7 @@ export function createSpawnSystem(options = {}) {
       const gameStatus = world.getResource(gameStatusResourceKey);
       const ghostIds = world.getResource(ghostIdsResourceKey);
       const deadGhostIds = world.getResource(deadGhostIdsResourceKey) || [];
+      const eventQueue = world.getResource(eventQueueResourceKey);
       const mapResource = world.getResource(mapResourceKey);
       const existingSpawnState = world.getResource(spawnResourceKey);
 
@@ -445,8 +535,22 @@ export function createSpawnSystem(options = {}) {
         spawnState.elapsedMs += getDeltaMs(context);
       }
 
-      if (deadGhostIds.length > 0) {
-        consumeDeadGhostIds(spawnState, deadGhostIds);
+      // BUG-01: collision-system marks fire-killed ghosts DEAD but never
+      // writes their ids into deadGhostIds itself; bridge that gap here from
+      // the GhostDefeated events it already emits on the shared queue.
+      if (eventQueue !== scratch.lastSeenEventQueue) {
+        // A new eventQueue instance (restart) resets frame/order to zero, so
+        // a watermark from the previous instance must not carry over.
+        scratch.lastSeenEventQueue = eventQueue;
+        scratch.lastSeenGhostDefeated.frame = -1;
+        scratch.lastSeenGhostDefeated.order = -1;
+      }
+      const bridgedDeadGhostIds = peekGhostDefeatedIds(eventQueue, scratch.lastSeenGhostDefeated);
+      const allDeadGhostIds =
+        bridgedDeadGhostIds.length > 0 ? deadGhostIds.concat(bridgedDeadGhostIds) : deadGhostIds;
+
+      if (allDeadGhostIds.length > 0) {
+        consumeDeadGhostIds(spawnState, allDeadGhostIds);
         // Death intents are edge-triggered. Clear them once consumed so the
         // same death cannot be re-applied after the queued respawn releases.
         world.setResource(deadGhostIdsResourceKey, []);

--- a/src/ecs/systems/spawn-system.js
+++ b/src/ecs/systems/spawn-system.js
@@ -28,11 +28,11 @@
  *   provides a deterministic ghost entity ordering resource.
  */
 
-import { peek } from '../resources/event-queue.js';
 import {
   GHOST_RESPAWN_MS as CANONICAL_GHOST_RESPAWN_MS,
   GHOST_SPAWN_DELAYS as CANONICAL_GHOST_SPAWN_DELAYS,
 } from '../resources/constants.js';
+import { peek } from '../resources/event-queue.js';
 import { GAME_STATE } from '../resources/game-status.js';
 import { GAMEPLAY_EVENT_TYPE } from './collision-gameplay-events.js';
 

--- a/tests/integration/gameplay/bug-01-ghost-respawn-bridge.test.js
+++ b/tests/integration/gameplay/bug-01-ghost-respawn-bridge.test.js
@@ -30,7 +30,10 @@ import {
   COLLISION_ENTITY_REQUIRED_MASK,
   createCollisionSystem,
 } from '../../../src/ecs/systems/collision-system.js';
-import { createInitialSpawnState, createSpawnSystem } from '../../../src/ecs/systems/spawn-system.js';
+import {
+  createInitialSpawnState,
+  createSpawnSystem,
+} from '../../../src/ecs/systems/spawn-system.js';
 import { World } from '../../../src/ecs/world/world.js';
 
 function createGhostRespawnRawMap() {

--- a/tests/integration/gameplay/bug-01-ghost-respawn-bridge.test.js
+++ b/tests/integration/gameplay/bug-01-ghost-respawn-bridge.test.js
@@ -1,0 +1,143 @@
+/**
+ * Integration test: bomb-killed ghosts must respawn.
+ *
+ * collision-system transitions a fire-killed ghost's state to DEAD and emits
+ * a GhostDefeated gameplay event, but nothing wrote the killed ghost's id into
+ * the deadGhostIds resource that spawn-system's respawn pipeline reads —
+ * scheduleRespawn was never called, so the ghost stayed dead forever.
+ *
+ * This test drives collision-system then spawn-system in the real bootstrap
+ * logic-phase order (collision-system before spawn-system), matching the
+ * issue's verification requirement: a bomb/fire kill must land the ghost's id
+ * in deadGhostIds and the ghost must return to NORMAL at the spawn position
+ * after GHOST_RESPAWN_MS.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { createGhostStore } from '../../../src/ecs/components/actors.js';
+import { COMPONENT_MASK } from '../../../src/ecs/components/registry.js';
+import {
+  COLLIDER_TYPE,
+  createColliderStore,
+  createPositionStore,
+} from '../../../src/ecs/components/spatial.js';
+import { createHealthStore } from '../../../src/ecs/components/stats.js';
+import { GHOST_RESPAWN_MS, GHOST_STATE } from '../../../src/ecs/resources/constants.js';
+import { createEventQueue } from '../../../src/ecs/resources/event-queue.js';
+import { createMapResource } from '../../../src/ecs/resources/map-resource.js';
+import {
+  COLLISION_ENTITY_REQUIRED_MASK,
+  createCollisionSystem,
+} from '../../../src/ecs/systems/collision-system.js';
+import { createInitialSpawnState, createSpawnSystem } from '../../../src/ecs/systems/spawn-system.js';
+import { World } from '../../../src/ecs/world/world.js';
+
+function createGhostRespawnRawMap() {
+  return {
+    level: 1,
+    metadata: {
+      activeGhostTypes: [0],
+      ghostSpeed: 4,
+      maxGhosts: 1,
+      name: 'BUG-01 Ghost Respawn Harness',
+      timerSeconds: 120,
+    },
+    dimensions: { rows: 5, columns: 5 },
+    grid: [
+      [1, 1, 1, 1, 1],
+      [1, 0, 0, 0, 1],
+      [1, 0, 6, 0, 1],
+      [1, 0, 5, 0, 1],
+      [1, 1, 1, 1, 1],
+    ],
+    spawn: {
+      ghostHouse: { bottomRow: 3, leftCol: 2, rightCol: 2, topRow: 3 },
+      ghostSpawnPoint: { row: 3, col: 2 },
+      player: { row: 2, col: 2 },
+    },
+  };
+}
+
+function placeEntity(positionStore, entityId, row, col) {
+  positionStore.prevRow[entityId] = row;
+  positionStore.prevCol[entityId] = col;
+  positionStore.row[entityId] = row;
+  positionStore.col[entityId] = col;
+  positionStore.targetRow[entityId] = row;
+  positionStore.targetCol[entityId] = col;
+}
+
+function addCollisionEntity(world, positionStore, colliderStore, colliderType, row, col) {
+  const entity = world.createEntity(COLLISION_ENTITY_REQUIRED_MASK);
+  colliderStore.type[entity.id] = colliderType;
+  placeEntity(positionStore, entity.id, row, col);
+  return entity;
+}
+
+describe('BUG-01 bomb-killed ghosts respawn', () => {
+  it('bridges a fire-killed ghost into deadGhostIds and respawns it to NORMAL after GHOST_RESPAWN_MS', () => {
+    const world = new World();
+    const mapResource = createMapResource(createGhostRespawnRawMap());
+    const maxEntities = 8;
+    const positionStore = createPositionStore(maxEntities);
+    const colliderStore = createColliderStore(maxEntities);
+    const ghostStore = createGhostStore(maxEntities);
+    const healthStore = createHealthStore(maxEntities);
+    const eventQueue = createEventQueue();
+    const collisionIntents = [];
+
+    const ghost = world.createEntity(COLLISION_ENTITY_REQUIRED_MASK | COMPONENT_MASK.GHOST);
+    colliderStore.type[ghost.id] = COLLIDER_TYPE.GHOST;
+    ghostStore.state[ghost.id] = GHOST_STATE.NORMAL;
+    placeEntity(positionStore, ghost.id, 2, 2);
+
+    // Fire lands on the ghost's tile, matching a bomb detonation reaching it.
+    addCollisionEntity(world, positionStore, colliderStore, COLLIDER_TYPE.FIRE, 2, 2);
+
+    world.setResource('mapResource', mapResource);
+    world.setResource('position', positionStore);
+    world.setResource('collider', colliderStore);
+    world.setResource('ghost', ghostStore);
+    world.setResource('health', healthStore);
+    world.setResource('collisionIntents', collisionIntents);
+    world.setResource('eventQueue', eventQueue);
+    world.setResource('ghostIds', [ghost.id]);
+    world.setResource('deadGhostIds', []);
+    world.setResource('ghostSpawnState', createInitialSpawnState());
+    world.setResource('gameStatus', { currentState: 'PLAYING' });
+
+    // Bootstrap wiring registers collision-system before spawn-system in the
+    // logic phase (src/game/bootstrap.js ~L378, ~L404) — match that order.
+    world.registerSystem(createCollisionSystem());
+    world.registerSystem(createSpawnSystem());
+
+    world.runFixedStep({ dtMs: 0, frame: 0 });
+
+    expect(ghostStore.state[ghost.id]).toBe(GHOST_STATE.DEAD);
+
+    // The core BUG-01 assertion: the collision system's kill must have been
+    // bridged into a scheduled respawn, not silently dropped.
+    const spawnState = world.getResource('ghostSpawnState');
+    expect(spawnState.respawnQueue.some((entry) => entry.ghostId === ghost.id)).toBe(true);
+
+    // Advance simulated time past the respawn delay across further fixed
+    // steps and confirm the ghost actually comes back.
+    const stepMs = 250;
+    let elapsedMs = 0;
+    let frame = 1;
+    while (elapsedMs <= GHOST_RESPAWN_MS) {
+      world.runFixedStep({ dtMs: stepMs, frame });
+      elapsedMs += stepMs;
+      frame += 1;
+    }
+
+    // spawn-system owns respawn-queue bookkeeping and re-release; the actual
+    // ghostStore.state flip back to NORMAL is ghost-ai-system's job (Track B,
+    // out of this fix's scope) once it observes the ghost back in
+    // releasedGhostIds — verified here at the spawn-system boundary.
+    const finalSpawnState = world.getResource('ghostSpawnState');
+    expect(finalSpawnState.respawnQueue).toHaveLength(0);
+    expect(finalSpawnState.releasedGhostIds).toContain(ghost.id);
+  });
+});

--- a/tests/unit/systems/spawn-system.test.js
+++ b/tests/unit/systems/spawn-system.test.js
@@ -8,7 +8,9 @@
 
 import { describe, expect, it } from 'vitest';
 
+import { createEventQueue, enqueue } from '../../../src/ecs/resources/event-queue.js';
 import { createGameStatus, GAME_STATE } from '../../../src/ecs/resources/game-status.js';
+import { GAMEPLAY_EVENT_TYPE } from '../../../src/ecs/systems/collision-gameplay-events.js';
 import {
   createInitialSpawnState,
   createSpawnSystem,
@@ -510,6 +512,87 @@ describe('spawn-system', () => {
         { ghostId: 4, readyAtMs: 2000 },
       ],
       activeGhostCap: 2,
+    });
+  });
+
+  describe('BUG-01: GhostDefeated event bridge', () => {
+    it('schedules a respawn for a ghost id observed only via a GhostDefeated event', () => {
+      const { spawnSystem, world } = createSpawnHarness();
+      const eventQueue = createEventQueue();
+      enqueue(eventQueue, GAMEPLAY_EVENT_TYPE.GHOST_DEFEATED, { entityId: 2 }, 0);
+      world.setResource('eventQueue', eventQueue);
+
+      updateSpawn(spawnSystem, world, 0);
+
+      expect(getSpawnState(world).respawnQueue).toEqual([
+        { ghostId: 2, readyAtMs: getRespawnDelayMs() },
+      ]);
+    });
+
+    it('does not re-schedule the same still-undrained GhostDefeated event on a later tick', () => {
+      const { spawnSystem, world } = createSpawnHarness();
+      const eventQueue = createEventQueue();
+      enqueue(eventQueue, GAMEPLAY_EVENT_TYPE.GHOST_DEFEATED, { entityId: 2 }, 0);
+      world.setResource('eventQueue', eventQueue);
+
+      updateSpawn(spawnSystem, world, 0);
+      // The queue is never drained here (no audio-cue-system registered), so
+      // the same event is still present on this next tick.
+      advanceSpawnTime(spawnSystem, world, getRespawnDelayMs() + 1000);
+
+      // If the stale event were re-bridged after the ghost's first respawn
+      // entry cleared, readyAtMs would jump forward again instead of the
+      // ghost staying released.
+      const spawnState = getSpawnState(world);
+      expect(spawnState.respawnQueue).toEqual([]);
+      expect(spawnState.releasedGhostIds).toContain(2);
+    });
+
+    it('ignores GhostDefeated events already bridged even across multiple ticks before a drain', () => {
+      const { spawnSystem, world } = createSpawnHarness();
+      const eventQueue = createEventQueue();
+      enqueue(eventQueue, GAMEPLAY_EVENT_TYPE.GHOST_DEFEATED, { entityId: 2 }, 0);
+      world.setResource('eventQueue', eventQueue);
+
+      updateSpawn(spawnSystem, world, 0);
+      updateSpawn(spawnSystem, world, 0);
+      updateSpawn(spawnSystem, world, 0);
+
+      // Only ever scheduled once despite three ticks observing the same event.
+      expect(getSpawnState(world).respawnQueue).toHaveLength(1);
+    });
+
+    it('resets the bridge watermark when the eventQueue instance changes (restart)', () => {
+      const { spawnSystem, world } = createSpawnHarness();
+      const firstQueue = createEventQueue();
+      enqueue(firstQueue, GAMEPLAY_EVENT_TYPE.GHOST_DEFEATED, { entityId: 2 }, 5);
+      world.setResource('eventQueue', firstQueue);
+      updateSpawn(spawnSystem, world, 0);
+
+      // Restart replaces eventQueue with a brand new instance whose frame/
+      // order counters restart from zero (see bootstrap.js's onRestart).
+      const secondQueue = createEventQueue();
+      enqueue(secondQueue, GAMEPLAY_EVENT_TYPE.GHOST_DEFEATED, { entityId: 3 }, 0);
+      world.setResource('eventQueue', secondQueue);
+      world.setResource(DEFAULT_SPAWN_RESOURCE_KEY, createInitialSpawnState());
+
+      updateSpawn(spawnSystem, world, 0);
+
+      // A stale watermark from the first queue (frame: 5) would reject every
+      // post-restart event (frame: 0) as "not newer" — ghost 3 must still be
+      // bridged and scheduled for respawn.
+      expect(
+        getSpawnState(world).respawnQueue.some((entry) => entry.ghostId === 3),
+      ).toBe(true);
+    });
+
+    it('does not throw and behaves as before when no eventQueue resource is present', () => {
+      const { spawnSystem, world } = createSpawnHarness({ deadGhostIds: [7] });
+
+      expect(() => updateSpawn(spawnSystem, world, 0)).not.toThrow();
+      expect(
+        getSpawnState(world).respawnQueue.some((entry) => entry.ghostId === 7),
+      ).toBe(true);
     });
   });
 });

--- a/tests/unit/systems/spawn-system.test.js
+++ b/tests/unit/systems/spawn-system.test.js
@@ -581,18 +581,14 @@ describe('spawn-system', () => {
       // A stale watermark from the first queue (frame: 5) would reject every
       // post-restart event (frame: 0) as "not newer" — ghost 3 must still be
       // bridged and scheduled for respawn.
-      expect(
-        getSpawnState(world).respawnQueue.some((entry) => entry.ghostId === 3),
-      ).toBe(true);
+      expect(getSpawnState(world).respawnQueue.some((entry) => entry.ghostId === 3)).toBe(true);
     });
 
     it('does not throw and behaves as before when no eventQueue resource is present', () => {
       const { spawnSystem, world } = createSpawnHarness({ deadGhostIds: [7] });
 
       expect(() => updateSpawn(spawnSystem, world, 0)).not.toThrow();
-      expect(
-        getSpawnState(world).respawnQueue.some((entry) => entry.ghostId === 7),
-      ).toBe(true);
+      expect(getSpawnState(world).respawnQueue.some((entry) => entry.ghostId === 7)).toBe(true);
     });
   });
 });


### PR DESCRIPTION
# 🚀 Bomb-killed ghosts never respawn, resolved entirely in Track C
> **Summary**: Fixes #228 (CRITICAL) by bridging the missing collision→spawn signal from within `spawn-system.js`, without touching `collision-system.js`.

---

## 📝 Description

### 🔄 What Changed
- **spawn-system**: `createSpawnSystem` now also reads the shared `eventQueue` resource and peeks (never drains) `GhostDefeated` events, merging their `entityId`s into the same `deadGhostIds` intent list the respawn pipeline already consumes.
- Added a per-system-instance `(frame, order)` watermark so the same still-undrained `GhostDefeated` event is bridged exactly once, and resets when the `eventQueue` instance changes (restart).
- No changes to `collision-system.js`, `bootstrap.js`, or any other file.

### 🎯 Why
- **The bug**: `collision-system` transitions a fire-killed ghost's state to `DEAD` and already emits a `GhostDefeated` gameplay event, but nothing ever wrote that ghost's id into `deadGhostIds` — the resource `spawn-system`'s respawn pipeline reads to call `scheduleRespawn`. Killed ghosts stayed dead forever; on later levels, every ghost was eventually eliminated permanently, breaking the core chase loop.
- **Why Track C only, not Track B**: the issue is filed as `Track: B / C` because its first proposed fix option — having `collision-system` write `deadGhostIds` directly — would touch Track B. Its second proposed option — "introduce a logic-phase bridging step before spawn-system executes" — does not. `collision-system` already emits `GhostDefeated` (with the ghost's `entityId`) on the shared `eventQueue`, and `spawn-system` already runs after `collision-system` in the same logic phase (`bootstrap.js`), so the bridge fits entirely inside `spawn-system.js` with zero Track B changes.
- **Coordination**: the issue's own `Assignee:` field names `@alexsmyr0` as primary owner, with `chrisbaikas` as a secondary Track C-scoped assignee. Confirmed no open PR against #228 existed before this one. Chose the Track-C-only path specifically so this fix carries no risk of conflicting with any Track B work `@alexsmyr0` might be doing independently — this PR should be reviewable/mergeable without blocking on or colliding with Track B changes.
- **Why `peek()`, not `drain()`**: `drain(eventQueue)` is the queue's single canonical one-shot consumption point, called once per frame by the render-phase `audio-cue-system` (see `event-queue.js`'s D-01 contract and `main.ecs.js`). If `spawn-system` (logic phase, runs earlier) called `drain()` too, it would delete `GhostDefeated` events before the audio system could see them, silently breaking the `sfx-ghost-kill` cue. `peek()` is non-destructive, so both consumers independently observe the same frame's events.
- **Why the watermark, not just `scheduleRespawn`'s dedupe guard**: `peek()` alone isn't safe — an event lingers in the queue until the render-phase drain runs, so on every tick before that drain, a naive peek would re-observe the same event. This surfaced during testing: once a ghost's original respawn queue entry cleared (ghost released), a subsequent tick re-peeking the same stale event re-scheduled it, incorrectly resetting a *new* countdown for the *same already-returned* ghost. Tracking the highest `(frame, order)` envelope already bridged (event queue envelope fields, not ad hoc state) makes each event consumed exactly once regardless of drain timing. The watermark resets when the `eventQueue` object identity changes, since restart replaces it with a fresh instance whose counters restart from zero (`bootstrap.js`'s `onRestart`) — without that reset, a stale high watermark would reject every post-restart event.

---

## 🧪 Verification & Audit

### ✅ Verification
- [x] **Master Check**: `npm run policy` — passes except the pre-existing, environment-only `test:e2e` ENOSPC failure (inotify instance exhaustion from concurrently running editor/agent processes; documented as pre-existing and unrelated to code changes across the prior PRs in this same audit sweep — #292, #293, #296). `npx vitest run` (97 files / 1300 tests) passes with zero failures; `policy:repo` passes cleanly.
- [x] Wrote `tests/integration/gameplay/bug-01-ghost-respawn-bridge.test.js` FIRST, matching the issue's verification requirement: places a fire entity on a released ghost's tile, steps `collision-system` then `spawn-system` in real bootstrap logic-phase order, and confirms the kill lands in the respawn queue and the ghost is back in `releasedGhostIds` after `GHOST_RESPAWN_MS`. Confirmed it fails against the current `main` (ghost dies but is never scheduled for respawn) before applying the fix.
- [x] Added 5 unit tests to `tests/unit/systems/spawn-system.test.js` covering the bridge directly: schedules from a `GhostDefeated` event, does not re-schedule the same stale event after the ghost already returned, ignores an already-bridged event across repeated ticks, resets the watermark on an `eventQueue` instance swap (restart), and behaves exactly as before when no `eventQueue` resource is present at all (backward compatible with every existing caller).
- [x] Deliberately verified two of these tests (restart-watermark-reset, stale-event-no-reschedule) by temporarily reverting the corresponding lines and confirming they fail — both are genuine regression guards, not tautological.

### 📋 Audit Traceability
- N/A — ad hoc GitHub-issue bugfix branch (`bugfix-*` convention), not a tracked `C-NN` ticket with `AUDIT-XX` entries.

---

## ✅ PR Gate Checklist

### 📋 Required Checks
- [x] **Read Standards**: Reviewed `AGENTS.md` and the agentic workflow guide.
- [x] **Policy Compliance**: Ran `npm run policy` locally; all checks pass except the pre-existing environmental `test:e2e` ENOSPC failure.
- [x] **Ownership**: `src/ecs/systems/spawn-system.js` and its tests are entirely Track C (`spawn-*.js` pattern) — a clean same-track edit, not a bugfix-mode bypass of cross-track scope.
- [x] **Branching**: Uses the repo's documented `bugfix-*` convention since #228 is an ad hoc GitHub issue rather than a tracked `C-NN` feature ticket.
- [ ] **Audit Coverage**: Not applicable — no F-01–F-21/B-01–B-06 items are affected.
- [ ] **Evidence**: Not applicable — no F-19/F-20/F-21/B-06 manual evidence required for this scope.

### 🏗️ Architecture & Security
- [x] **ECS Isolation**: No DOM references added; `spawn-system.js` remains a pure logic-phase system.
- [x] **Adapter Injection**: No adapter access added or changed.
- [x] **Safe Sinks**: No DOM sinks touched.
- [x] **No Bloat**: No framework or canvas API imports introduced.
- [x] **Dependencies**: No dependency or lockfile changes.

---

## 🛡️ Security & Architecture Notes
- **Security**: No new trust boundaries or sinks.
- **Architecture**: `spawn-system.js` already imports shared gameplay-event constants indirectly through the established cross-track pattern (`timer-system.js`, a Track C file, already imports from `collision-gameplay-events.js`, a Track B-owned shared-contract module) — this PR follows that same precedent for `GAMEPLAY_EVENT_TYPE`. `eventQueue` is added to `spawn-system`'s **read-only** capability declaration; its write capability list is unchanged, so the ECS scheduler's resource-access tracing still accurately reflects that `spawn-system` never mutates the shared queue.
- **Risks**: The `peek()`-without-drain approach depends on the render-phase `audio-cue-system` remaining the sole `drain()` call site — if that assumption ever changes (e.g., a second system starts draining the queue mid-frame), the watermark logic here would need re-verification. This is documented directly in `spawn-system.js`'s `peekGhostDefeatedIds` docstring.