### PR TITLE
Asmyrogl/bugfix policy gate

### DIFF
--- a/docs/audit-reports/pr-audit-medvall-bugfix-coverage-275-285.md
+++ b/docs/audit-reports/pr-audit-medvall-bugfix-coverage-275-285.md
@@ -1,0 +1,77 @@
+# 🛡️ Audit: `medvall/bugfix-coverage-275-285`
+## 🏁 Verdict: **FAIL**
+
+> PR [#291](https://github.com/ertval/make-your-game/pull/291) — grading issues **#275 (CI-11, reduced-motion)** and **#285 (CI-13, dev-mode DOM budget)**.
+> The code is architecturally clean and the failing gate is caused by pre-existing e2e flakes (not this PR), but the PR does **not** meet the strict merge bar: a blocking narrative/implementation drift and two unmet *mandatory* verification requirements.
+
+---
+
+## 🎯 Scope & Compliance
+- **Ticket ID**: `#275 (label CI-11)` + `#285 (label CI-13)` — labels are **ad-hoc**, not `ticket-tracker.md` / `AUDIT-*` IDs | **Track**: `D` (owner `medvall`), spanning `D/C` (#275) and `D/A` (#285)
+- **Audit Mode**: `GENERAL_DOCS_PROCESS` (bugfix-branch → owner-scoped process checks; confirmed by the gate's own resolution banner)
+- **Base Comparison**: PR scope = `37e24a6..HEAD` (4 commits, +223 lines, 5 files): `805c862` #285, `0c5276c` #275, `072120d` pr-message, `9548f28` `!important`→custom-props
+
+### 📦 Deliverables & Verification
+- **PASS**: `#275` CSS reduced-motion override — every current animation/transition routes through one of the 8 zeroed `--anim-*-duration` custom properties (`animations.css:203-211`); no hardcoded non-zero duration exists anywhere in `styles/`, so nothing is missed **today**.
+- **PASS**: `#275` e2e spec shape — `emulateMedia({reducedMotion:'reduce'})`, triggers the start overlay, asserts `animation`/`transition` durations `=== 0` (`tests/e2e/reduced-motion.spec.js`). Passed in the full run.
+- **PASS**: `#285` `assertDomElementBudget` function + wiring — `> 500` throws / `= 500` passes, dev-gated via `isDevelopment()`, surfaced through the startup `catch → renderCriticalError` (`src/main.ecs.js:277,290-302,855-861`). 4 unit tests exercise it; e2e `AUDIT-CI-09` DOM-budget test passed (10.0s).
+- **FAIL**: `#275` **mandatory red-first TDD** — the issue states *"You MUST write a FAILING test that reproduces this issue BEFORE implementing the fix."* The PR body openly admits the e2e "passed against unmodified code" — the test was **green from the start**.
+- **PARTIAL**: `#285` verification requirement — the issue requires asserting *"the **application** throws a **visible** initialization error"* with a mocked >500-element load. The 4 tests exercise the **standalone function only**; no test drives `bootstrapApplication` → `renderCriticalError` with an over-budget document.
+- **Out-of-Scope Findings**: `none` — `src/main.ecs.js` (Track A) is legitimately carried under the bugfix bypass; no dependency/lockfile changes.
+
+---
+
+## 🔍 Audit Findings & Blockers
+### 🚨 Critical (Blockers)
+1. **Documentation ⇆ implementation drift (blocking).** The PR body and `docs/pr-messages/bugfix-coverage-275-285-pr.md:26,44` describe the #275 fix as a **universal `!important` safety net** — `*, *::before, *::after { …-duration: 0s !important }`. The **shipped** code (commit `9548f28`) is a **different, narrower** approach: `:root { --anim-*-duration: 0s }` zeroing **8 enumerated variables**. The body's central claim — *"compliance no longer depends on every future selector being hand-added"* — is **false for what shipped**: the custom-property approach only neutralizes declarations that reference one of those 8 variables, and is therefore **weaker/more fragile** for any future or literal-duration animation than the `!important` net it describes. `!important` is **not** forbidden anywhere (no stylelint, AGENTS.md silent, policy gate does not scan it), so the swap was stylistic — but the narrative was never updated. Merging would land a PR whose description materially misrepresents the merged code.
+
+### ⚠️ High/Medium/Low
+1. **(Medium)** `#275` violates the ticket's explicit *MUST write a failing test first* (self-admitted green-from-start).
+2. **(Medium)** `#285` verification is incomplete — tests the function, not the mandated **application-level visible init error** (`bootstrap → renderCriticalError` path is never driven with >500 elements).
+3. **(Low)** Site-wide e2e omits the animation assertion — `reduced-motion.spec.js:78` checks `site.maxTransition` only; `scanMotion` already computes `maxAnimation` but it's unused site-wide, so a stray non-overlay decorative **animation** would escape both tests.
+4. **(Low)** Traceability — `#275`/`#285`/`CI-11`/`CI-13` map to **no** row in `docs/implementation/audit-traceability-matrix.md`; the reduced-motion and DOM≤500 MUSTs remain unmapped even after adding their tests.
+5. **(Low)** PR-template — bespoke bugfix layout, no canonical `AUDIT-* | Execution Type | Verification | Evidence` block.
+
+> [!IMPORTANT]
+> ### ⛑️ Path To PASS (Required)
+> 1. **Fix the narrative (blocker).** Rewrite the #275 section of the PR body + pr-message to describe the shipped `:root` custom-property approach and **delete** the false "no longer depends on every future selector" guarantee — **or** restore a genuinely universal `*, *::before, *::after { animation-duration:0s; transition-duration:0s }` fallback (it can coexist with the custom props) and keep the claim honest.
+> 2. **Satisfy #285's mandated test.** Add a `bootstrapApplication` test with `isDevelopment()=true` and a `documentRef` whose `querySelectorAll('*')` returns `{length:501}`, asserting the app throws **and** `renderCriticalError`/overlay surfaced the error.
+> 3. **Address #275 red-first** — either provide failing-first evidence or explicitly reclassify the ticket (its premise "zero implementation" was inaccurate; per-animation handling already existed).
+> 4. *(Recommended)* Add `expect(site.maxAnimation).toBe(0)` to the site-wide test; add matrix rows mapping both MUSTs to their new tests; register/replace the `CI-11`/`CI-13` labels.
+
+---
+
+## 📋 Requirements, Audit & Drift
+- **REQ IDs**: reduced-motion is an `AGENTS.md:161` MUST (not in `requirements.md`); DOM≤500 is `AGENTS.md:208` MUST (mirrored `README.md:287`) | **AUDIT IDs**: none mapped (labels are ad-hoc)
+- **PARTIAL**: Coverage evidence — new tests exist and pass, but neither MUST is mapped in the traceability matrix.
+- **PASS**: Manual evidence (F-19/F-20/F-21/B-06) unaffected — reduced-motion only zeroes durations; DOM guard is dev-only; no paint/layer/promotion or production render path changes (matrix sign-off intact).
+- **FAIL**: Drift — **documentation drift** (PR body describes unshipped `!important` net; false robustness claim). **No** feature/gameplay drift and **no** technical/architecture drift.
+
+---
+
+## 🛠️ Automated Gate Summary
+- **FAIL**: `npm run policy -- --require-approval=false` (**exit=1**, duration≈**354s**). Failure isolated to `policy:quality` → `test:e2e` (**4 failed / 58 passed**). Unit: **1298 passed**. Biome, schema, sbom, forbidden, header, trace all green.
+- **Root cause = pre-existing e2e flakes, NOT this PR.** The 4 failures were all `Test timeout of 60000ms exceeded` (contention), in code paths this PR does not touch:
+  - `audit.browser.spec.js:324` AUDIT-B-05 long-task • `race-condition.spec.js:34` pause/resume simTime • `render-desync-bugs.spec.js:84` bomb sprite • `track-c-integration.spec.js:9` pause menu
+- **Verification Pass (isolation re-run)**: all 4 **PASS alone**, collapsing from 60s+ timeouts to **2.7s / 2.5s / 1.1s / 2.6s**. Confirmed environmental flakes (match the repo's documented flaky clusters), not regressions. The new `reduced-motion.spec.js` and `AUDIT-CI-09` DOM-budget test passed in the full run.
+- **Net**: the gate as-run is **red on known flakes**; a clean serial/isolated run of the changed-scope tests is green. The gate must be green (or flakes quarantined) for merge, but no PR-attributable test failure exists.
+
+---
+
+## ✅ Policy Matrix
+- **PASS**: Ticket/Track Context — bugfix mode resolved to Track D (owner `medvall`); cross-track bundle explicitly allowed.
+- **PASS**: Ownership & PR Template — ownership bypass **legitimate** (`medvall` is a registered Track-D owner; `BUGFIX_BRANCH_PATTERN` match; owner-prefix vs GitHub login `edvallm` is irrelevant to the gate). *Template body PARTIAL (non-blocking).*
+- **PASS**: ECS DOM Boundary & Adapter Injection — `src/ecs/systems/` untouched; the only new DOM access (`document.querySelectorAll('*')`) is at the composition root, dev-gated.
+- **PASS**: Forbidden Tech (canvas/WebGL/frameworks) — none introduced (scan of 3 changed JS files + repo-wide 189-file scan green).
+- **PASS**: Security Sinks (innerHTML/eval/timers) — none; breach message is plain `textContent` via `renderCriticalError`.
+- **PASS**: Timing, Input, & Rendering Invariants — unaffected (dev-only guard; CSS scoped to the reduced-motion media query).
+- **PASS**: New Files Header Comments — the one new file (`reduced-motion.spec.js`) has a conformant header; header gate green.
+- **PARTIAL**: Audit Traceability Matrix Mapping — no rows for reduced-motion / DOM≤500; ad-hoc CI-11/CI-13.
+- **FAIL**: No Gameplay/Document/Technical Drift — **documentation drift** present (see Blocker #1).
+
+---
+
+## 📄 Final Report Metadata
+- **Date**: 2026-07-04
+- **READY_FOR_MAIN**: **NO**
+- **Note**: Failure is driven by (a) a blocking PR-narrative/implementation drift and (b) two unmet *mandatory* per-ticket verification requirements — **not** by the flaky e2e gate, which is confirmed PR-neutral. The underlying code (reduced-motion CSS + dev-mode DOM budget assertion) is sound and close to mergeable once the narrative is corrected and #285's application-level test is added.

--- a/docs/audit-reports/pr-audit-pr304-ekaramet-bugfix-A-250-clock-event-fixes.md
+++ b/docs/audit-reports/pr-audit-pr304-ekaramet-bugfix-A-250-clock-event-fixes.md
@@ -1,0 +1,158 @@
+# 🛡️ Audit: `ekaramet/bugfix-A-250-clock-event-fixes` (PR #304)
+## 🏁 Verdict: **FAIL** — *merge-blocked on gate hygiene only; implementation is correct*
+
+> **Independent reviewer audit** (asmyrogl) of [PR #304](https://github.com/ertval/make-your-game/pull/304).
+> Distinct from the author's self-audit that ships inside the PR
+> (`docs/audit-reports/pr-audit-ekaramet-bugfix-A-250-clock-event-fixes.md`).
+>
+> **Read this first:** The *code* for all three issues is implemented correctly and is
+> fully covered by passing unit/integration tests. The FAIL verdict is **not** about
+> the implementation logic. It reflects two non-code gate items: (1) the canonical
+> `npm run policy` umbrella gate exited **1** on this run (root cause = **proven-flaky**
+> e2e under suite contention — all 5 failures pass in isolation in 5.8s), and (2) minor
+> confirmed technical/documentation drift. The Path to PASS is trivial and listed below.
+
+---
+
+## 🎯 Scope & Compliance
+- **Ticket IDs**: #250 = **DEAD-02**, #256 = **DEAD-08**, #238 = **BUG-03** | **Track**: `A` (single track ✔)
+- **Audit Mode**: `GENERAL_DOCS_PROCESS` (bugfix-branch bypass; see Policy Matrix)
+- **Base Comparison**: `merge-base(main, HEAD)=1ef20e4 .. 9e1baa8` — 11 files, +190 / −35
+- **Note on tracking**: #250/#256/#238 are **GitHub issue numbers**, not internal tracker IDs
+  (tracker space is `A-01..A-14`, etc.). Deliverable specs live in
+  `docs/audit-reports/phase-3-4/audit-report-p3-4-consolidated-2026-07-02.md`, not in
+  `ticket-tracker.md` / `track-a.md`.
+
+### 📦 Deliverables & Verification
+- ✅ **#250 (DEAD-02)** — Removed unreachable `if (processMode)` block in `assertTicketAssociation`
+  (`scripts/policy-gate/run-checks.mjs`, was ~L227-234). Verified genuinely dead: an earlier
+  unconditional `if (processMode) return createProcessFallback(...)` at `run-checks.mjs:190-196`
+  guarantees any later statement runs only when `processMode` is falsy. No orphaned code —
+  `createProcessFallback` (def L143, calls L171/L191) and `processMode` (L64,92,104,180,190,244…)
+  remain in use. **Correct & behavior-preserving.**
+- ✅ **#256 (DEAD-08)** — Doc comments added to `HIGH_SCORE_STORAGE_KEY` (`storage-adapter.js:11`)
+  and `AUDIO_CUE_MAPPING` (`audio-integration.js:84`); exports retained; test asserts both still
+  import and match. **Correct (informational ticket, fully satisfied).**
+- ✅ **#238 (BUG-03)** — Canonical drain relocated to end of `stepFrame` (`bootstrap.js:1057-1060`,
+  `const events = eventQueue ? drain(eventQueue) : []`), returned in the frame result
+  (`bootstrap.js:1069`); audio runner switched `drain`→`peek` (`audio-integration.js:66,307`);
+  redundant rAF-loop drain removed from `main.ecs.js`. **Ordering verified correct** (see Critical
+  check below). **Correct — memory-leak on null-audio path is genuinely fixed.**
+- **Out-of-Scope Findings**: `none` — all source edits stay within the three tickets' declared
+  Track A files.
+
+---
+
+## 🔍 Audit Findings & Blockers
+
+### 🚨 Critical (Blockers)
+1. **None in the implementation.** The single decisive automated gate (`npm run policy`) exited **1**,
+   but failure isolation proves the cause is **flaky e2e under suite contention**, not this PR
+   (see Automated Gate Summary). Because the canonical gate is red on its run, merge is
+   procedurally blocked until a clean gate run is produced.
+
+### ⚠️ High/Medium/Low
+1. **[LOW–MEDIUM · Technical/Doc drift]** The `audio-cue-system` now `peek`s (read-only) but still
+   declares `write: [eventQueueResourceKey]` with a now-**false** comment
+   *"drain() clears the queue, so this system writes the event-queue resource"* (`bootstrap.js:148-149`).
+   Impact is **not** a correctness/scheduler bug — `resourceCapabilities` is a capability grant/guard,
+   not a parallel-conflict scheduler (systems run sequentially per phase) — but the `write` grant is
+   now vestigial/over-permissive and the comment misrepresents the code.
+2. **[LOW · Doc drift]** Three additional stale "drain" comments contradict the new `peek` behavior:
+   `bootstrap.js:120` ("maps **drained** gameplay events"), `bootstrap.js:361-362` ("appended last …
+   so it **drains every gameplay event**"), and `audio-integration.js:53-55` (module header still says
+   the runner uses `drain` and does **not** `peek` — doubly wrong).
+3. **[LOW · Test fidelity #238]** The dedicated new test (`bootstrap-extended.test.js:287-298`) is a
+   **10-iteration unit** test using manual `enqueue('TestEvent', …)`, whereas the ticket specified a
+   **100-iteration integration** test driving **real event-producing gameplay** with a null audio
+   adapter. Boundedness is proven (asserts `events.length === 0` each frame), and the two updated
+   190-frame `a-05-integration.test.js` blocks (L553-575, L638-660) exercise real gameplay with an
+   absent adapter — so intent is covered in aggregate, but the literal spec test does not exist.
+4. **[LOW · Test quality #250]** The DEAD-02 test (`policy-utils.test.js:454-467`) is a **brittle
+   source-text grep** (reads the file as a string, slices between function-name anchors, asserts no
+   second `if (processMode)`), not a behavioral assertion. Meets the ticket's loose wording but breaks
+   if functions are renamed/reordered.
+
+> [!IMPORTANT]
+> ### ⛑️ Path To PASS (Required if FAIL)
+> 1. **Produce a green gate run** (blocker): re-run `npm run policy -- --require-approval=false` on a
+>    quiet machine, or re-run `npm run test:e2e` until the flaky audit/render/stress specs pass
+>    together. Proven flaky — the 5 failures pass in isolation in **5.8s** (`--workers=1 --retries=0`).
+>    Consider quarantining/retry-annotating AUDIT-F-14, render-desync #84/#104/#248, and the
+>    race-condition simTime stress spec to stop them gating unrelated PRs.
+> 2. **(Recommended, not strictly blocking)** Fix the drift: drop the vestigial
+>    `write: [eventQueueResourceKey]` grant and correct the 4 stale `drain`/`peek` comments
+>    (`bootstrap.js:120,148-149,361-362`; `audio-integration.js:53-55`).
+> 3. **(Optional)** Strengthen the #238 test toward the ticket's 100-iteration integration spec, and
+>    make the #250 test behavioral rather than a source-text grep.
+
+---
+
+## 📋 Requirements, Audit & Drift
+- **REQ IDs**: none (issue-driven bugfixes) | **AUDIT IDs**: DEAD-02 / DEAD-08 / BUG-03
+  (defined only in the phase-3-4 consolidated report)
+- ✅ **Coverage evidence**: 1298/1298 vitest tests pass (`policy:quality → test:coverage`); the 4
+  changed/added test files pass in isolation (bootstrap-extended 12/12, policy-utils 36/36,
+  audio-integration 36/36, a-05-integration 5/5).
+- ✅ **Manual evidence (F-19/20/21/B-06)**: undisturbed — no diff references or backing files touched.
+- ⚠️ **Technical/Doc drift**: **PRESENT (LOW–MEDIUM)** — vestigial `write` capability + 4 stale
+  comments (findings ⚠️1–2). **Feature/audio drift: NONE** — cues still fire (ordering verified).
+  **Traceability drift: LOW** — #250/#256/#238 leave no `ticket-tracker`/`audit-traceability-matrix`
+  footprint (accepted under bugfix mode, but no record is created).
+
+### 🔬 Critical check — #238 ordering (no audio regression)
+`stepFrame` runs `world.runRenderCommit(...)` at `bootstrap.js:1045`, which dispatches the
+render-phase `audio-cue-system` (`bootstrap.js:139`, `phase:'render'`). That system `peek`s the
+queue **before** the new drain at `bootstrap.js:1059-1060`. Both use the **same** resolved
+`eventQueueResourceKey` (default `'eventQueue'`) — no key divergence. `peek()` returns a sorted copy
+without mutating (`event-queue.js:113-120`); `drain()` clears + resets `orderCounter`
+(`event-queue.js:78-100`). **Audio observes every event, then the queue is cleared exactly once per
+frame.** ✔
+
+---
+
+## 🛠️ Automated Gate Summary
+- ❌ **`npm run policy -- --require-approval=false`** — **exit=1, duration≈731s (12m11s)**.
+  Failure isolated to **Phase 1 `policy:quality` → `test:e2e`**: **5 failed / 55 passed (12.0m)**.
+  Signatures: `net::ERR_NETWORK_IO_SUSPENDED`, `Target page/browser has been closed`, and multiple
+  `Test timeout of 60000ms exceeded` (individual tests hung 8.4m) = severe suite contention /
+  webserver suspension.
+- ✅ **Failure isolation** (orchestrator, narrow):
+  - `policy:checks` → **PASS** (bugfix-mode; owner `ekaramet` = Track A; ownership check skipped)
+  - `policy:forbidden` → **PASS** (9 changed + 188 repo files clean)
+  - `policy:header` → **PASS** (5 files; 2 new files are `docs/*.md`, no new source headers required)
+  - `policy:trace` → **PASS** (repo-wide invariants; matrix/manifest untouched)
+  - biome `check` → **PASS**; vitest `test:coverage` → **PASS (1298/1298)**
+- ✅ **Verification pass** — the 5 failing e2e specs re-run in isolation (`--workers=1 --retries=0`):
+  **5 passed (5.8s)**. Failures are **flaky/environmental, not PR-caused.** None of the failing
+  specs (bomb-sprite #84, pellet-DOM #104, power-up-icon, AUDIT-F-14 HUD, pause/resume race) touch
+  the PR's code paths (policy script, storage/audio adapters, drain relocation).
+
+---
+
+## ✅ Policy Matrix
+- ✅ **Ticket/Track Context Valid** — single Track A; issue-driven bugfix via bugfix-branch mode
+- ✅ **Ownership & PR Template Respected** — owner `ekaramet` owns Track A; PR body fills all required
+  sections. *Observation:* PR ships the author's own **PASS** self-audit — noted, not a substitute
+  for this independent review.
+- ✅ **ECS DOM Boundary & Adapter Injection** — no `src/ecs/systems/` files touched; adapters resolved
+  via World resources
+- ✅ **Forbidden Tech (canvas/WebGL/frameworks)** — none introduced
+- ✅ **Security Sinks (innerHTML/eval/timers)** — none introduced (`var`/`require`/XHR clean)
+- ✅ **Timing, Input, & Rendering Invariants** — accumulator/rAF/resume unaffected; drain relocation is
+  runtime-equivalent (drained every frame, correct order)
+- ✅ **New Files Header Comments** — the 2 new files are docs (`.md`), no source-header requirement
+- ⚠️ **Audit Traceability Matrix Mapping** — N/A for GitHub-issue bugfixes; no matrix footprint created
+- ⚠️ **No Gameplay/Document/Technical Drift** — **gameplay: none**; **technical/documentation: present
+  (LOW–MEDIUM)** — vestigial `write` capability + 4 stale `drain`/`peek` comments
+
+---
+
+## 📄 Final Report Metadata
+- **Date**: 2026-07-04
+- **READY_FOR_MAIN**: **NO** — *gate hygiene only.* The implementation of #250/#256/#238 is correct
+  and test-covered. Merge is blocked solely on (a) a clean `npm run policy` run (current red is
+  proven-flaky e2e) and, recommended, (b) the LOW–MEDIUM drift cleanup. No code-logic blocker exists.
+- **Reviewer evidence**: `.agents/scratch/scope-audit.md`, `.agents/scratch/policy-audit.md`,
+  `.agents/scratch/gate-audit.md`, `.agents/scratch/policy-gate-run.log`,
+  `.agents/scratch/e2e-isolation-rerun.log`

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -31,6 +31,14 @@ export default defineConfig({
   // Retry once in CI only: covers the transient webServer connection race
   // without masking a deterministic failure (a real break fails both attempts).
   retries: isCI ? 1 : 0,
+  // Hard cap on parallel workers. Each worker launches its own Chromium, and
+  // launchOptions below disables the frame-rate limiter, so every worker's rAF
+  // loop spins a CPU core at 100%. Left unset, Playwright defaults to "50%" of
+  // logical cores (4 workers on an 8-core machine); 4 unthrottled Chromium
+  // instances plus their helper processes saturate every core and can hard-
+  // freeze a fanless machine. Capping at 2 guarantees a run can never pin all
+  // cores, whoever launches it (local dev, the policy gate, or an audit).
+  workers: 2,
   use: {
     baseURL: 'http://127.0.0.1:4173',
     trace: 'retain-on-failure',

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -27,27 +27,43 @@ export default defineConfig({
     timeout: 10_000,
   },
   testMatch: '**/*.spec.js',
-  testIgnore: ignoreAuditTests ? ['**/audit/**'] : undefined,
   // Retry once in CI only: covers the transient webServer connection race
   // without masking a deterministic failure (a real break fails both attempts).
   retries: isCI ? 1 : 0,
-  // Hard cap on parallel workers. Each worker launches its own Chromium, and
-  // launchOptions below disables the frame-rate limiter, so every worker's rAF
-  // loop spins a CPU core at 100%. Left unset, Playwright defaults to "50%" of
-  // logical cores (4 workers on an 8-core machine); 4 unthrottled Chromium
-  // instances plus their helper processes saturate every core and can hard-
-  // freeze a fanless machine. Capping at 2 guarantees a run can never pin all
-  // cores, whoever launches it (local dev, the policy gate, or an audit).
+  // Hard cap on parallel workers. Each worker launches its own Chromium. Left
+  // unset, Playwright defaults to "50%" of logical cores (4 workers on an
+  // 8-core machine), which can saturate every core and hard-freeze a fanless
+  // machine. Capping at 2 bounds how many cores any run can touch.
   workers: 2,
   use: {
     baseURL: 'http://127.0.0.1:4173',
     trace: 'retain-on-failure',
-    launchOptions: {
-      // Unlock the frame rate so rAF is driven by the real frame budget, not
-      // the headless compositor's vsync cap. Required for accurate F-17/F-18.
-      args: ['--disable-gpu-vsync', '--disable-frame-rate-limit'],
-    },
   },
+  // The frame-rate limiter is disabled ONLY for the audit perf specs (F-17/F-18)
+  // that must measure the real frame budget instead of the headless compositor's
+  // ~30 Hz vsync cap. Every other spec keeps vsync ON, so its browser idles
+  // instead of pinning a core at 100% — the difference between a whole suite
+  // cooking a fanless CPU and one perf spec briefly loading it. Dropping the
+  // audit project when PLAYWRIGHT_IGNORE_AUDIT is set preserves the gate's skip.
+  projects: [
+    {
+      name: 'e2e',
+      testIgnore: ['**/audit/**'],
+    },
+    ...(ignoreAuditTests
+      ? []
+      : [
+          {
+            name: 'audit',
+            testMatch: '**/audit/**/*.spec.js',
+            use: {
+              launchOptions: {
+                args: ['--disable-gpu-vsync', '--disable-frame-rate-limit'],
+              },
+            },
+          },
+        ]),
+  ],
   webServer: {
     command: 'npm run dev -- --host 127.0.0.1 --port 4173',
     port: 4173,


### PR DESCRIPTION
The e2e suite could saturate every core and hard-freeze a fanless machine:
Playwright defaulted to 50% of logical cores (4 workers on an 8-core M2), and
the global --disable-gpu-vsync/--disable-frame-rate-limit flags made every
browser spin a core at 100% instead of idling at vsync.
Cap workers at 2, and move the frame-rate flags into an audit-only project so
only the F-17/F-18 perf specs (which must measure the real frame budget) run
unthrottled. The other ~42 specs now run vsync-capped and idle. Dropping the
audit project when PLAYWRIGHT_IGNORE_AUDIT is set preserves the gate's skip.