### PR TITLE
Medvall/bugfix correctness 237 239 244

### DIFF
--- a/docs/pr-messages/bugfix-correctness-237-239-244-pr.md
+++ b/docs/pr-messages/bugfix-correctness-237-239-244-pr.md
@@ -1,0 +1,50 @@
+# 🔧 bugfix: resource/timing/map correctness — #237 #239 #244
+
+> Three Track D correctness fixes (all assigned to @edvallm) on one `bugfix-*` branch: a clock time-regression freeze, an inconsistent `drain()` return contract, and a test-env schema fail-open. `bugfix-*` bypasses ownership; all changes are within Track D resources. #237 and #239 were committed earlier and carried on this branch; #244 is new here.
+
+## Required checks
+
+- [x] I read AGENTS.md and the agentic workflow guide.
+- [x] I ran `npm run policy` locally.
+- [x] Branch name follows `<owner>/bugfix-<slug>` (`medvall/bugfix-correctness-237-239-244`).
+- [x] Changed files are within Track D (`src/ecs/resources/*`); test fixtures updated across tracks under the bugfix bypass.
+- [x] Each fix has a failing-first repro test.
+- [x] Checked security sinks, architecture boundaries, dependency impact (none).
+- [x] Requested human review.
+
+## What changed
+
+### #237 (BUG-02) — clock resyncs after a backward time regression
+- `src/ecs/resources/clock.js`: on a backward jump (`now < lastFrameTime`) the baseline now resyncs `lastFrameTime`/`realTimeMs` to the new (lower) timestamp, costing a single 0-step frame instead of freezing the sim until real time re-passed the stale high baseline.
+- Test: `clock.test.js` — "resynchronizes after a backward time regression instead of freezing (#237)".
+
+### #239 (BUG-04) — `drain()` returns a consistently mutable array
+- `src/ecs/resources/event-queue.js`: empty frames return a fresh mutable `[]` instead of a frozen `Object.freeze([])` singleton, so consumers that sort/splice/push in place no longer throw only on quiet frames.
+- Test: `event-queue.test.js` — "returns a consistently mutable array for empty and populated drains (#239)".
+
+### #244 (BUG-13) — structural map-schema validation runs in tests (no fail-open)
+- `src/ecs/resources/map-resource.js`: `validateMapSchema` no longer returns `true` unconditionally under `NODE_ENV=test`. **Structural** checks (required fields, types, cell enum, `additionalProperties`, metadata/spawn shape) now always run; only **production dimensional limits** (level 1–3, board 10–100, grid width, metadata ranges) are relaxed by default in tests so focused small fixtures still work. `createMapResource` gains an explicit `{ validateSchema: false }` per-call escape hatch for tests that deliberately build invalid maps (e.g. the missing-`ghostSpeed` fallback repro).
+- Fixed genuinely-malformed fixtures surfaced by the newly-active validation: `activeGhostTypes: ['red', …]` → integer indices `[0,1,2,3]` in `level-transition-spawn-reset` and `bootstrap-extended`.
+- Test: `map-resource.test.js` — "runs structural schema validation in the test env but relaxes production dimensions (#244)" asserts a structural defect is rejected under the test env and the escape hatch still lets deliberate-invalid maps through.
+
+## Tests
+
+- `npx vitest run` — **1305 passed** (incl. the three repro tests).
+- `npm run check` — clean. `npm run policy` — green modulo the pre-existing e2e timing-flake cluster (`#84`/`race-condition`).
+
+## Audit questions affected
+
+- **F-01** (runs without crashing): #237 removes a sim-freeze failure mode; #239 removes a latent `TypeError` on quiet frames.
+- **Test integrity**: #244 closes a fail-open where malformed maps could pass the suite — strengthens the guarantees behind the map-loading audit coverage.
+
+## Security notes
+
+- #244 tightens a trust boundary: malformed map data is now rejected in tests as it is in production. No new sinks or dependencies.
+
+## Architecture / dependency notes
+
+- No dependency/lockfile changes. `createMapResource`'s new optional `{ validateSchema }` is backward-compatible (defaults to `true`).
+
+## Risks
+
+- Low. All three are localized to `src/ecs/resources/*` with direct unit coverage. The #244 change is the broadest — it was validated by bringing the full suite back to green (the previously fail-open fixtures were either legitimately small, now-relaxed, or genuinely malformed, now fixed).

--- a/src/ecs/resources/clock.js
+++ b/src/ecs/resources/clock.js
@@ -76,9 +76,12 @@ export function tickClock(
     frameTime = 0;
   }
 
-  // Update wall-clock baseline if it was invalid or if time moved forward.
-  // We do NOT update if there was a regression (stick to last known good).
-  if (!isBaselineValid || (!isTimeRegression && timestamp > clock.lastFrameTime)) {
+  // Update the wall-clock baseline if it was invalid, if time moved forward, OR
+  // on a regression (#237). Resyncing to the new (lower) timestamp on a backward
+  // jump costs a single 0-step frame but keeps the clock live afterward. Sticking
+  // to the stale high baseline would instead return 0 steps on every subsequent
+  // tick until real time exceeded it — freezing the sim for the whole gap.
+  if (!isBaselineValid || isTimeRegression || timestamp > clock.lastFrameTime) {
     clock.lastFrameTime = timestamp;
     clock.realTimeMs = timestamp;
   }

--- a/src/ecs/resources/event-queue.js
+++ b/src/ecs/resources/event-queue.js
@@ -78,7 +78,10 @@ export function enqueue(queue, type, payload, frame) {
 export function drain(queue) {
   if (queue.events.length === 0) {
     queue.orderCounter = 0;
-    return _EMPTY_DRAIN;
+    // Return a fresh mutable array (#239): the empty branch previously returned
+    // a frozen singleton, so consumers that mutate the result in place (sort,
+    // splice, push) worked on active frames but threw a TypeError on quiet ones.
+    return [];
   }
 
   // Sort by frame first, then by insertion order within the same frame.
@@ -98,9 +101,6 @@ export function drain(queue) {
 
   return result;
 }
-
-/** Frozen singleton returned for empty drains to avoid the [] allocation. */
-const _EMPTY_DRAIN = Object.freeze([]);
 
 /**
  * Return all events sorted by (frame, order) without clearing the queue.

--- a/src/ecs/resources/map-resource.js
+++ b/src/ecs/resources/map-resource.js
@@ -367,17 +367,23 @@ export function validateMapSemantic(rawMap) {
  * @param {object} rawMap - Raw map JSON object.
  * @returns {{ ok: boolean, errors: string[] }}
  */
-export function validateMapSchema(rawMap) {
-  const isTestEnv = typeof process !== 'undefined' && process.env?.NODE_ENV === 'test';
-  if (isTestEnv && rawMap.__testSchemaValidation__ !== true) {
-    return { ok: true, errors: [] };
-  }
-
+export function validateMapSchema(rawMap, options = {}) {
   const errors = [];
 
   if (!rawMap || typeof rawMap !== 'object' || Array.isArray(rawMap)) {
     return { ok: false, errors: ['Map payload is not a valid JSON object'] };
   }
+
+  // Structural checks (required fields, types, cell enum, additionalProperties,
+  // metadata/spawn shape) ALWAYS run — including in tests — so genuinely malformed
+  // maps can never slip past the suite (#244). Only the production *dimensional*
+  // limits (level 1-3, board 10-100, grid row width 10-100) are relaxed by default
+  // in the test env, so focused unit tests can keep using small fixtures. Force
+  // the full production checks with `__testSchemaValidation__: true` on the map or
+  // `{ relaxDimensions: false }` in options.
+  const isTestEnv = typeof process !== 'undefined' && process.env?.NODE_ENV === 'test';
+  const relaxDimensions =
+    options.relaxDimensions ?? (isTestEnv && rawMap.__testSchemaValidation__ !== true);
 
   // 1. Root required properties
   const rootRequired = ['level', 'metadata', 'dimensions', 'grid', 'spawn'];
@@ -414,13 +420,10 @@ export function validateMapSchema(rawMap) {
     }
   }
 
-  // 4. level type and range
-  if (
-    typeof rawMap.level !== 'number' ||
-    !Number.isInteger(rawMap.level) ||
-    rawMap.level < 1 ||
-    rawMap.level > 3
-  ) {
+  // 4. level type (always) and production range (relaxable)
+  if (typeof rawMap.level !== 'number' || !Number.isInteger(rawMap.level)) {
+    errors.push('Property "level" must be an integer');
+  } else if (!relaxDimensions && (rawMap.level < 1 || rawMap.level > 3)) {
     errors.push('Property "level" must be an integer between 1 and 3');
   }
 
@@ -439,33 +442,29 @@ export function validateMapSchema(rawMap) {
     }
     if (errors.length === 0) {
       const { name, timerSeconds, maxGhosts, ghostSpeed, activeGhostTypes } = rawMap.metadata;
-      if (typeof name !== 'string' || name.length < 1 || name.length > 100) {
+      if (typeof name !== 'string') {
+        errors.push('metadata.name must be a string');
+      } else if (!relaxDimensions && (name.length < 1 || name.length > 100)) {
         errors.push('metadata.name must be a string between 1 and 100 characters');
       }
-      if (
-        typeof timerSeconds !== 'number' ||
-        !Number.isInteger(timerSeconds) ||
-        timerSeconds < 1 ||
-        timerSeconds > 600
-      ) {
+      if (typeof timerSeconds !== 'number' || !Number.isInteger(timerSeconds)) {
+        errors.push('metadata.timerSeconds must be an integer');
+      } else if (!relaxDimensions && (timerSeconds < 1 || timerSeconds > 600)) {
         errors.push('metadata.timerSeconds must be an integer between 1 and 600');
       }
-      if (
-        typeof maxGhosts !== 'number' ||
-        !Number.isInteger(maxGhosts) ||
-        maxGhosts < 1 ||
-        maxGhosts > 4
-      ) {
+      if (typeof maxGhosts !== 'number' || !Number.isInteger(maxGhosts)) {
+        errors.push('metadata.maxGhosts must be an integer');
+      } else if (!relaxDimensions && (maxGhosts < 1 || maxGhosts > 4)) {
         errors.push('metadata.maxGhosts must be an integer between 1 and 4');
       }
-      if (typeof ghostSpeed !== 'number' || ghostSpeed < 1.0 || ghostSpeed > 10.0) {
+      if (typeof ghostSpeed !== 'number') {
+        errors.push('metadata.ghostSpeed must be a number');
+      } else if (!relaxDimensions && (ghostSpeed < 1.0 || ghostSpeed > 10.0)) {
         errors.push('metadata.ghostSpeed must be a number between 1.0 and 10.0');
       }
-      if (
-        !Array.isArray(activeGhostTypes) ||
-        activeGhostTypes.length < 1 ||
-        activeGhostTypes.length > 4
-      ) {
+      if (!Array.isArray(activeGhostTypes)) {
+        errors.push('metadata.activeGhostTypes must be an array');
+      } else if (!relaxDimensions && (activeGhostTypes.length < 1 || activeGhostTypes.length > 4)) {
         errors.push('metadata.activeGhostTypes must be an array with 1 to 4 items');
       } else {
         const seen = new Set();
@@ -504,15 +503,14 @@ export function validateMapSchema(rawMap) {
     }
     if (errors.length === 0) {
       const { columns, rows } = rawMap.dimensions;
-      if (
-        typeof columns !== 'number' ||
-        !Number.isInteger(columns) ||
-        columns < 10 ||
-        columns > 100
-      ) {
+      if (typeof columns !== 'number' || !Number.isInteger(columns)) {
+        errors.push('dimensions.columns must be an integer');
+      } else if (!relaxDimensions && (columns < 10 || columns > 100)) {
         errors.push('dimensions.columns must be an integer between 10 and 100');
       }
-      if (typeof rows !== 'number' || !Number.isInteger(rows) || rows < 10 || rows > 100) {
+      if (typeof rows !== 'number' || !Number.isInteger(rows)) {
+        errors.push('dimensions.rows must be an integer');
+      } else if (!relaxDimensions && (rows < 10 || rows > 100)) {
         errors.push('dimensions.rows must be an integer between 10 and 100');
       }
     }
@@ -531,7 +529,7 @@ export function validateMapSchema(rawMap) {
       if (!Array.isArray(row)) {
         errors.push(`grid[${r}] must be a valid JSON array`);
       } else {
-        if (row.length < 10 || row.length > 100) {
+        if (!relaxDimensions && (row.length < 10 || row.length > 100)) {
           errors.push(`grid[${r}] must have between 10 and 100 items`);
         }
         for (let c = 0; c < row.length; c += 1) {
@@ -787,11 +785,17 @@ export function assertValidMapResource(map) {
  * @param {object} rawMap — Raw map JSON object (as loaded from JSON file).
  * @returns {MapResource}
  */
-export function createMapResource(rawMap) {
-  // Schema validation — throws on failure.
-  const schemaVal = validateMapSchema(rawMap);
-  if (!schemaVal.ok) {
-    throw new Error(`Map schema validation failed: ${schemaVal.errors.join('; ')}`);
+export function createMapResource(rawMap, { validateSchema = true } = {}) {
+  // Schema validation — throws on failure. `validateSchema: false` is an explicit
+  // escape hatch for tests that deliberately construct a structurally-invalid map
+  // to exercise runtime robustness (e.g. a missing `ghostSpeed` fallback); it is
+  // opt-out per call and visible in the test, so it does not reintroduce the
+  // silent test-env fail-open this replaced (#244).
+  if (validateSchema) {
+    const schemaVal = validateMapSchema(rawMap);
+    if (!schemaVal.ok) {
+      throw new Error(`Map schema validation failed: ${schemaVal.errors.join('; ')}`);
+    }
   }
 
   // Semantic validation — throws on failure.

--- a/tests/integration/gameplay/ghost-default-speed-fallback.test.js
+++ b/tests/integration/gameplay/ghost-default-speed-fallback.test.js
@@ -65,7 +65,10 @@ function buildWorld() {
   const positionStore = createPositionStore(16);
   const velocityStore = createVelocityStore(16);
   const playerStore = createPlayerStore(16);
-  const mapResource = createMapResource(createNoSpeedMap());
+  // This map deliberately omits the required `ghostSpeed` to exercise the runtime
+  // fallback (#130), so it opts out of the always-on structural schema check
+  // (#244) — the escape hatch is explicit and visible here.
+  const mapResource = createMapResource(createNoSpeedMap(), { validateSchema: false });
 
   const playerEntity = world.createEntity(COMPONENT_MASK.PLAYER | COMPONENT_MASK.POSITION);
   positionStore.row[playerEntity.id] = mapResource.playerSpawnRow;

--- a/tests/integration/gameplay/level-transition-spawn-reset.test.js
+++ b/tests/integration/gameplay/level-transition-spawn-reset.test.js
@@ -13,7 +13,7 @@ describe('level-transition-spawn-reset', () => {
         timerSeconds: 60,
         maxGhosts: 4,
         ghostSpeed: 1,
-        activeGhostTypes: ['red', 'pink', 'cyan', 'orange'],
+        activeGhostTypes: [0, 1, 2, 3],
       },
       dimensions: { rows: 5, columns: 5 },
       grid: [
@@ -37,7 +37,7 @@ describe('level-transition-spawn-reset', () => {
         timerSeconds: 60,
         maxGhosts: 4,
         ghostSpeed: 1,
-        activeGhostTypes: ['red', 'pink', 'cyan', 'orange'],
+        activeGhostTypes: [0, 1, 2, 3],
       },
       dimensions: { rows: 5, columns: 5 },
       grid: [
@@ -102,7 +102,7 @@ describe('level-transition-spawn-reset', () => {
         timerSeconds: 60,
         maxGhosts: 4,
         ghostSpeed: 1,
-        activeGhostTypes: ['red', 'pink', 'cyan', 'orange'],
+        activeGhostTypes: [0, 1, 2, 3],
       },
       dimensions: { rows: 5, columns: 5 },
       grid: [

--- a/tests/unit/game/bootstrap-extended.test.js
+++ b/tests/unit/game/bootstrap-extended.test.js
@@ -103,7 +103,7 @@ describe('Bootstrap extended coverage', () => {
         timerSeconds: 60,
         maxGhosts: 1,
         ghostSpeed: 1,
-        activeGhostTypes: ['red'],
+        activeGhostTypes: [0],
       },
       dimensions: { rows: 5, columns: 5 },
       grid: [
@@ -152,7 +152,7 @@ describe('Bootstrap extended coverage', () => {
         timerSeconds: 60,
         maxGhosts: 4,
         ghostSpeed: 1,
-        activeGhostTypes: ['red', 'pink', 'cyan', 'orange'],
+        activeGhostTypes: [0, 1, 2, 3],
       },
       dimensions: { rows: 5, columns: 5 },
       grid: [

--- a/tests/unit/resources/clock.test.js
+++ b/tests/unit/resources/clock.test.js
@@ -113,7 +113,25 @@ describe('clock', () => {
     const clock = createClock(100);
     const steps = tickClock(clock, 50);
     expect(steps).toBe(0); // Should not produce negative steps or synthetic progress
-    expect(clock.lastFrameTime).toBe(100); // Should stick to last known good time
+    // #237: on a regression, resync the baseline to the new (lower) timestamp
+    // rather than sticking to the stale high one (which would freeze the sim).
+    expect(clock.lastFrameTime).toBe(50);
+  });
+
+  it('resynchronizes after a backward time regression instead of freezing (#237)', () => {
+    const clock = createClock(0);
+    // Advance to a high baseline.
+    tickClock(clock, 1000);
+    // Backward jump to a much lower timestamp (e.g. a non-monotonic clock adjust).
+    expect(tickClock(clock, 100)).toBe(0); // the single jump frame yields no steps
+
+    // Two subsequent forward steps that are STILL below the old baseline (1000).
+    // Before the fix the stale baseline made these negative deltas → 0 steps
+    // (frozen for the whole regression gap). After the fix the baseline resynced
+    // to 100, so forward progress resumes stepping.
+    tickClock(clock, 100 + FIXED_DT_MS);
+    const resumedSteps = tickClock(clock, 100 + 2 * FIXED_DT_MS);
+    expect(resumedSteps).toBeGreaterThanOrEqual(1);
   });
 
   it('prevents NaN propagation when tickClock is called with non-finite values (BUG-01)', () => {

--- a/tests/unit/resources/event-queue.test.js
+++ b/tests/unit/resources/event-queue.test.js
@@ -122,4 +122,21 @@ describe('event-queue', () => {
   it('does not throw when queue is undefined (BUG-15)', () => {
     expect(() => enqueue(undefined, 'Test', {}, 0)).not.toThrow();
   });
+
+  it('returns a consistently mutable array for empty and populated drains (#239)', () => {
+    const queue = createEventQueue();
+
+    // Empty frame: before the fix this returned a frozen singleton, so an
+    // in-place mutation (sort/splice/push) threw only on quiet frames.
+    const emptyResult = drain(queue);
+    expect(Array.isArray(emptyResult)).toBe(true);
+    expect(Object.isFrozen(emptyResult)).toBe(false);
+    expect(() => emptyResult.push('x')).not.toThrow();
+
+    // Populated frame: also mutable — identical contract.
+    enqueue(queue, 'BombDetonated', { bombId: 1 }, 1);
+    const populatedResult = drain(queue);
+    expect(Object.isFrozen(populatedResult)).toBe(false);
+    expect(() => populatedResult.push('y')).not.toThrow();
+  });
 });

--- a/tests/unit/resources/map-resource.test.js
+++ b/tests/unit/resources/map-resource.test.js
@@ -729,13 +729,46 @@ describe('map-resource — JSON Schema validation', () => {
 
     rawMap.level = 1.5;
     expect(() => createMapResource(rawMap)).toThrow(
-      'Map schema validation failed: Property "level" must be an integer between 1 and 3',
+      'Map schema validation failed: Property "level" must be an integer',
     );
 
     rawMap.level = '1';
     expect(() => createMapResource(rawMap)).toThrow(
-      'Map schema validation failed: Property "level" must be an integer between 1 and 3',
+      'Map schema validation failed: Property "level" must be an integer',
     );
+  });
+
+  it('runs structural schema validation in the test env but relaxes production dimensions (#244)', () => {
+    // Small, structurally-valid map WITHOUT the __testSchemaValidation__ opt-in:
+    // production dimension limits (board 10-100, level 1-3) are relaxed so focused
+    // fixtures work, but structural checks still run.
+    const smallValid = {
+      level: 1,
+      metadata: { name: 't', timerSeconds: 60, maxGhosts: 1, ghostSpeed: 4, activeGhostTypes: [0] },
+      dimensions: { rows: 5, columns: 5 },
+      grid: [
+        [1, 1, 1, 1, 1],
+        [1, 0, 3, 0, 1],
+        [1, 0, 5, 0, 1],
+        [1, 0, 0, 0, 1],
+        [1, 1, 1, 1, 1],
+      ],
+      spawn: {
+        player: { row: 1, col: 1 },
+        ghostHouse: { topRow: 2, bottomRow: 2, leftCol: 2, rightCol: 2 },
+        ghostSpawnPoint: { row: 2, col: 2 },
+      },
+    };
+    expect(() => createMapResource(smallValid)).not.toThrow();
+
+    // The test-env fail-open this closed: a structural defect (additionalProperty,
+    // which semantic validation ignores) is now rejected even under NODE_ENV=test.
+    const withExtra = structuredClone(smallValid);
+    withExtra.bogus = true;
+    expect(() => createMapResource(withExtra)).toThrow(/Additional property "bogus"/);
+
+    // The explicit per-call escape hatch still lets a deliberately-invalid map through.
+    expect(() => createMapResource(withExtra, { validateSchema: false })).not.toThrow();
   });
 
   it('rejects map with invalid metadata', () => {


### PR DESCRIPTION
# 🔧 bugfix: resource/timing/map correctness — #237 #239 #244

> Three Track D correctness fixes (all assigned to @edvallm) on one `bugfix-*` branch: a clock time-regression freeze, an inconsistent `drain()` return contract, and a test-env schema fail-open. `bugfix-*` bypasses ownership; all changes are within Track D resources. #237 and #239 were committed earlier and carried on this branch; #244 is new here.

## Required checks

- [x] I read AGENTS.md and the agentic workflow guide.
- [x] I ran `npm run policy` locally.
- [x] Branch name follows `<owner>/bugfix-<slug>` (`medvall/bugfix-correctness-237-239-244`).
- [x] Changed files are within Track D (`src/ecs/resources/*`); test fixtures updated across tracks under the bugfix bypass.
- [x] Each fix has a failing-first repro test.
- [x] Checked security sinks, architecture boundaries, dependency impact (none).
- [x] Requested human review.

## What changed

### #237 (BUG-02) — clock resyncs after a backward time regression
- `src/ecs/resources/clock.js`: on a backward jump (`now < lastFrameTime`) the baseline now resyncs `lastFrameTime`/`realTimeMs` to the new (lower) timestamp, costing a single 0-step frame instead of freezing the sim until real time re-passed the stale high baseline.
- Test: `clock.test.js` — "resynchronizes after a backward time regression instead of freezing (#237)".

### #239 (BUG-04) — `drain()` returns a consistently mutable array
- `src/ecs/resources/event-queue.js`: empty frames return a fresh mutable `[]` instead of a frozen `Object.freeze([])` singleton, so consumers that sort/splice/push in place no longer throw only on quiet frames.
- Test: `event-queue.test.js` — "returns a consistently mutable array for empty and populated drains (#239)".

### #244 (BUG-13) — structural map-schema validation runs in tests (no fail-open)
- `src/ecs/resources/map-resource.js`: `validateMapSchema` no longer returns `true` unconditionally under `NODE_ENV=test`. **Structural** checks (required fields, types, cell enum, `additionalProperties`, metadata/spawn shape) now always run; only **production dimensional limits** (level 1–3, board 10–100, grid width, metadata ranges) are relaxed by default in tests so focused small fixtures still work. `createMapResource` gains an explicit `{ validateSchema: false }` per-call escape hatch for tests that deliberately build invalid maps (e.g. the missing-`ghostSpeed` fallback repro).
- Fixed genuinely-malformed fixtures surfaced by the newly-active validation: `activeGhostTypes: ['red', …]` → integer indices `[0,1,2,3]` in `level-transition-spawn-reset` and `bootstrap-extended`.
- Test: `map-resource.test.js` — "runs structural schema validation in the test env but relaxes production dimensions (#244)" asserts a structural defect is rejected under the test env and the escape hatch still lets deliberate-invalid maps through.

## Tests

- `npx vitest run` — **1305 passed** (incl. the three repro tests).
- `npm run check` — clean. `npm run policy` — green modulo the pre-existing e2e timing-flake cluster (`#84`/`race-condition`).

## Audit questions affected

- **F-01** (runs without crashing): #237 removes a sim-freeze failure mode; #239 removes a latent `TypeError` on quiet frames.
- **Test integrity**: #244 closes a fail-open where malformed maps could pass the suite — strengthens the guarantees behind the map-loading audit coverage.

## Security notes

- #244 tightens a trust boundary: malformed map data is now rejected in tests as it is in production. No new sinks or dependencies.

## Architecture / dependency notes

- No dependency/lockfile changes. `createMapResource`'s new optional `{ validateSchema }` is backward-compatible (defaults to `true`).

## Risks

- Low. All three are localized to `src/ecs/resources/*` with direct unit coverage. The #244 change is the broadest — it was validated by bringing the full suite back to green (the previously fail-open fixtures were either legitimately small, now-relaxed, or genuinely malformed, now fixed).
